### PR TITLE
Fix: add version to MotionBuilder / MotionBuilderBuffer

### DIFF
--- a/src/LitMotion/Assets/LitMotion/Runtime/MotionBuilder.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/MotionBuilder.cs
@@ -24,6 +24,7 @@ namespace LitMotion
 
         public static void Return(MotionBuilderBuffer<TValue, TOptions> buffer)
         {
+            buffer.Version++;
             buffer.Duration = default;
             buffer.Ease = default;
             buffer.IgnoreTimeScale = default;
@@ -36,8 +37,14 @@ namespace LitMotion
             buffer.Scheduler = default;
             buffer.OnComplete = default;
             buffer.IsPreserved = default;
-            pool.Push(buffer);
+
+            if (buffer.Version != ushort.MaxValue)
+            {
+                pool.Push(buffer);
+            }
         }
+
+        public ushort Version;
 
         public float Duration;
         public Ease Ease;
@@ -70,8 +77,10 @@ namespace LitMotion
         internal MotionBuilder(MotionBuilderBuffer<TValue, TOptions> buffer)
         {
             this.buffer = buffer;
+            this.version = buffer.Version;
         }
 
+        internal ushort version;
         internal MotionBuilderBuffer<TValue, TOptions> buffer;
 
         /// <summary>
@@ -272,7 +281,7 @@ namespace LitMotion
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         readonly void CheckBuffer()
         {
-            if (buffer == null) throw new InvalidOperationException("MotionBuilder is either not initialized or has already run a Build (or Bind). If you want to build or bind multiple times, call Preseve() for MotionBuilder.");
+            if (buffer == null || buffer.Version != version) throw new InvalidOperationException("MotionBuilder is either not initialized or has already run a Build (or Bind). If you want to build or bind multiple times, call Preseve() for MotionBuilder.");
         }
     }
 }


### PR DESCRIPTION
`MotionBuilder`をメソッドチェーンの途中でキャッシュすると、すでにプールに戻った`MotionBuilderBuffer`にアクセスできてしまうようです。稀なパターンとは思いますが、例外を投げるように修正してみました。

```csharp
using LitMotion;
using LitMotion.Extensions;
using UnityEngine;

public class Test : MonoBehaviour
{
    private void Start()
    {
        var first = LMotion.Create(0f, 1f, 1f);
        first.WithLoops(-1).BindToPositionX(transform);
        
        var second = LMotion.Create(0f, 1f, 1f);
        first.WithEase(Ease.InOutBack); // yet accessible though the first has been disposed already (should throw)
        second.WithLoops(-1).BindToPositionY(transform); // the second will be done with the ease
    }
}
```