### PR TITLE
Change: IMotionAdapter argument to ref

### DIFF
--- a/src/LitMotion/Assets/LitMotion/Runtime/Adapters/FixedStringAdapters.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Adapters/FixedStringAdapters.cs
@@ -12,7 +12,7 @@ namespace LitMotion.Adapters
 {
     public readonly struct FixedString32BytesMotionAdapter : IMotionAdapter<FixedString32Bytes, StringOptions>
     {
-        public FixedString32Bytes Evaluate(in FixedString32Bytes startValue, in FixedString32Bytes endValue, in StringOptions options, in MotionEvaluationContext context)
+        public FixedString32Bytes Evaluate(ref FixedString32Bytes startValue, ref FixedString32Bytes endValue, ref StringOptions options, in MotionEvaluationContext context)
         {
             var start = startValue;
             var end = endValue;
@@ -24,7 +24,7 @@ namespace LitMotion.Adapters
 
     public readonly struct FixedString64BytesMotionAdapter : IMotionAdapter<FixedString64Bytes, StringOptions>
     {
-        public FixedString64Bytes Evaluate(in FixedString64Bytes startValue, in FixedString64Bytes endValue, in StringOptions options, in MotionEvaluationContext context)
+        public FixedString64Bytes Evaluate(ref FixedString64Bytes startValue, ref FixedString64Bytes endValue, ref StringOptions options, in MotionEvaluationContext context)
         {
             var start = startValue;
             var end = endValue;
@@ -36,7 +36,7 @@ namespace LitMotion.Adapters
 
     public readonly struct FixedString128BytesMotionAdapter : IMotionAdapter<FixedString128Bytes, StringOptions>
     {
-        public FixedString128Bytes Evaluate(in FixedString128Bytes startValue, in FixedString128Bytes endValue, in StringOptions options, in MotionEvaluationContext context)
+        public FixedString128Bytes Evaluate(ref FixedString128Bytes startValue, ref FixedString128Bytes endValue, ref StringOptions options, in MotionEvaluationContext context)
         {
             var start = startValue;
             var end = endValue;
@@ -48,7 +48,7 @@ namespace LitMotion.Adapters
 
     public readonly struct FixedString512BytesMotionAdapter : IMotionAdapter<FixedString512Bytes, StringOptions>
     {
-        public FixedString512Bytes Evaluate(in FixedString512Bytes startValue, in FixedString512Bytes endValue, in StringOptions options, in MotionEvaluationContext context)
+        public FixedString512Bytes Evaluate(ref FixedString512Bytes startValue, ref FixedString512Bytes endValue, ref StringOptions options, in MotionEvaluationContext context)
         {
             var start = startValue;
             var end = endValue;
@@ -60,7 +60,7 @@ namespace LitMotion.Adapters
 
     public readonly struct FixedString4096BytesMotionAdapter : IMotionAdapter<FixedString4096Bytes, StringOptions>
     {
-        public FixedString4096Bytes Evaluate(in FixedString4096Bytes startValue, in FixedString4096Bytes endValue, in StringOptions options, in MotionEvaluationContext context)
+        public FixedString4096Bytes Evaluate(ref FixedString4096Bytes startValue, ref FixedString4096Bytes endValue, ref StringOptions options, in MotionEvaluationContext context)
         {
             var start = startValue;
             var end = endValue;

--- a/src/LitMotion/Assets/LitMotion/Runtime/Adapters/PrimitiveMotionAdapters.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Adapters/PrimitiveMotionAdapters.cs
@@ -12,7 +12,7 @@ namespace LitMotion.Adapters
 {
     public readonly struct FloatMotionAdapter : IMotionAdapter<float, NoOptions>
     {
-        public float Evaluate(in float startValue, in float endValue, in NoOptions options, in MotionEvaluationContext context)
+        public float Evaluate(ref float startValue, ref float endValue, ref NoOptions options, in MotionEvaluationContext context)
         {
             return math.lerp(startValue, endValue, context.Progress);
         }
@@ -20,7 +20,7 @@ namespace LitMotion.Adapters
 
     public readonly struct DoubleMotionAdapter : IMotionAdapter<double, NoOptions>
     {
-        public double Evaluate(in double startValue, in double endValue, in NoOptions options, in MotionEvaluationContext context)
+        public double Evaluate(ref double startValue, ref double endValue, ref NoOptions options, in MotionEvaluationContext context)
         {
             return math.lerp(startValue, endValue, context.Progress);
         }
@@ -28,7 +28,7 @@ namespace LitMotion.Adapters
 
     public readonly struct IntMotionAdapter : IMotionAdapter<int, IntegerOptions>
     {
-        public int Evaluate(in int startValue, in int endValue, in IntegerOptions options, in MotionEvaluationContext context)
+        public int Evaluate(ref int startValue, ref int endValue, ref IntegerOptions options, in MotionEvaluationContext context)
         {
             var value = math.lerp(startValue, endValue, context.Progress);
 
@@ -44,7 +44,7 @@ namespace LitMotion.Adapters
     }
     public readonly struct LongMotionAdapter : IMotionAdapter<long, IntegerOptions>
     {
-        public long Evaluate(in long startValue, in long endValue, in IntegerOptions options, in MotionEvaluationContext context)
+        public long Evaluate(ref long startValue, ref long endValue, ref IntegerOptions options, in MotionEvaluationContext context)
         {
             var value = math.lerp((double)startValue, endValue, context.Progress);
 

--- a/src/LitMotion/Assets/LitMotion/Runtime/Adapters/PunchMotionAdapters.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Adapters/PunchMotionAdapters.cs
@@ -13,7 +13,7 @@ namespace LitMotion.Adapters
 
     public readonly struct FloatPunchMotionAdapter : IMotionAdapter<float, PunchOptions>
     {
-        public float Evaluate(in float startValue, in float endValue, in PunchOptions options, in MotionEvaluationContext context)
+        public float Evaluate(ref float startValue, ref float endValue, ref PunchOptions options, in MotionEvaluationContext context)
         {
             VibrationHelper.EvaluateStrength(endValue, options.Frequency, options.DampingRatio, context.Progress, out var result);
             return startValue + result;
@@ -22,7 +22,7 @@ namespace LitMotion.Adapters
 
     public readonly struct Vector2PunchMotionAdapter : IMotionAdapter<Vector2, PunchOptions>
     {
-        public Vector2 Evaluate(in Vector2 startValue, in Vector2 endValue, in PunchOptions options, in MotionEvaluationContext context)
+        public Vector2 Evaluate(ref Vector2 startValue, ref Vector2 endValue, ref PunchOptions options, in MotionEvaluationContext context)
         {
             VibrationHelper.EvaluateStrength(endValue, options.Frequency, options.DampingRatio, context.Progress, out var result);
             return startValue + result;
@@ -31,7 +31,7 @@ namespace LitMotion.Adapters
 
     public readonly struct Vector3PunchMotionAdapter : IMotionAdapter<Vector3, PunchOptions>
     {
-        public Vector3 Evaluate(in Vector3 startValue, in Vector3 endValue, in PunchOptions options, in MotionEvaluationContext context)
+        public Vector3 Evaluate(ref Vector3 startValue, ref Vector3 endValue, ref PunchOptions options, in MotionEvaluationContext context)
         {
             VibrationHelper.EvaluateStrength(endValue, options.Frequency, options.DampingRatio, context.Progress, out var result);
             return startValue + result;

--- a/src/LitMotion/Assets/LitMotion/Runtime/Adapters/ShakeMotionAdapters.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Adapters/ShakeMotionAdapters.cs
@@ -13,7 +13,7 @@ namespace LitMotion.Adapters
 
     public readonly struct FloatShakeMotionAdapter : IMotionAdapter<float, ShakeOptions>
     {
-        public float Evaluate(in float startValue, in float endValue, in ShakeOptions options, in MotionEvaluationContext context)
+        public float Evaluate(ref float startValue, ref float endValue, ref ShakeOptions options, in MotionEvaluationContext context)
         {
             VibrationHelper.EvaluateStrength(endValue, options.Frequency, options.DampingRatio, context.Progress, out var s);
             float multipliar;
@@ -23,7 +23,6 @@ namespace LitMotion.Adapters
             }
             else
             {
-                // Currently RandomState is defensively copied and the state is not changed. This requires changing the Adapter's option argument to ref.
                 multipliar = options.RandomState.NextFloat(-1f, 1f);
             }
             return startValue + s * multipliar;
@@ -32,7 +31,7 @@ namespace LitMotion.Adapters
 
     public readonly struct Vector2ShakeMotionAdapter : IMotionAdapter<Vector2, ShakeOptions>
     {
-        public Vector2 Evaluate(in Vector2 startValue, in Vector2 endValue, in ShakeOptions options, in MotionEvaluationContext context)
+        public Vector2 Evaluate(ref Vector2 startValue, ref Vector2 endValue, ref ShakeOptions options, in MotionEvaluationContext context)
         {
             VibrationHelper.EvaluateStrength(endValue, options.Frequency, options.DampingRatio, context.Progress, out var s);
             Vector2 multipliar;
@@ -50,7 +49,7 @@ namespace LitMotion.Adapters
 
     public readonly struct Vector3ShakeMotionAdapter : IMotionAdapter<Vector3, ShakeOptions>
     {
-        public Vector3 Evaluate(in Vector3 startValue, in Vector3 endValue, in ShakeOptions options, in MotionEvaluationContext context)
+        public Vector3 Evaluate(ref Vector3 startValue, ref Vector3 endValue, ref ShakeOptions options, in MotionEvaluationContext context)
         {
             VibrationHelper.EvaluateStrength(endValue, options.Frequency, options.DampingRatio, context.Progress, out var s);
             Vector3 multipliar;

--- a/src/LitMotion/Assets/LitMotion/Runtime/Adapters/UnityMotionAdapter.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Adapters/UnityMotionAdapter.cs
@@ -15,7 +15,7 @@ namespace LitMotion.Adapters
 {
     public readonly struct Vector2MotionAdapter : IMotionAdapter<Vector2, NoOptions>
     {
-        public Vector2 Evaluate(in Vector2 startValue, in Vector2 endValue, in NoOptions options, in MotionEvaluationContext context)
+        public Vector2 Evaluate(ref Vector2 startValue, ref Vector2 endValue, ref NoOptions options, in MotionEvaluationContext context)
         {
             return Vector2.LerpUnclamped(startValue, endValue, context.Progress);
         }
@@ -23,7 +23,7 @@ namespace LitMotion.Adapters
 
     public readonly struct Vector3MotionAdapter : IMotionAdapter<Vector3, NoOptions>
     {
-        public Vector3 Evaluate(in Vector3 startValue, in Vector3 endValue, in NoOptions options, in MotionEvaluationContext context)
+        public Vector3 Evaluate(ref Vector3 startValue, ref Vector3 endValue, ref NoOptions options, in MotionEvaluationContext context)
         {
             return Vector3.LerpUnclamped(startValue, endValue, context.Progress);
         }
@@ -31,7 +31,7 @@ namespace LitMotion.Adapters
 
     public readonly struct Vector4MotionAdapter : IMotionAdapter<Vector4, NoOptions>
     {
-        public Vector4 Evaluate(in Vector4 startValue, in Vector4 endValue, in NoOptions options, in MotionEvaluationContext context)
+        public Vector4 Evaluate(ref Vector4 startValue, ref Vector4 endValue, ref NoOptions options, in MotionEvaluationContext context)
         {
             return Vector4.LerpUnclamped(startValue, endValue, context.Progress);
         }
@@ -39,7 +39,7 @@ namespace LitMotion.Adapters
 
     public readonly struct QuaternionMotionAdapter : IMotionAdapter<Quaternion, NoOptions>
     {
-        public Quaternion Evaluate(in Quaternion startValue, in Quaternion endValue, in NoOptions options, in MotionEvaluationContext context)
+        public Quaternion Evaluate(ref Quaternion startValue, ref Quaternion endValue, ref NoOptions options, in MotionEvaluationContext context)
         {
             return Quaternion.LerpUnclamped(startValue, endValue, context.Progress);
         }
@@ -47,7 +47,7 @@ namespace LitMotion.Adapters
 
     public readonly struct ColorMotionAdapter : IMotionAdapter<Color, NoOptions>
     {
-        public Color Evaluate(in Color startValue, in Color endValue, in NoOptions options, in MotionEvaluationContext context)
+        public Color Evaluate(ref Color startValue, ref Color endValue, ref NoOptions options, in MotionEvaluationContext context)
         {
             return Color.LerpUnclamped(startValue, endValue, context.Progress);
         }
@@ -55,7 +55,7 @@ namespace LitMotion.Adapters
 
     public readonly struct RectMotionAdapter : IMotionAdapter<Rect, NoOptions>
     {
-        public Rect Evaluate(in Rect startValue, in Rect endValue, in NoOptions options, in MotionEvaluationContext context)
+        public Rect Evaluate(ref Rect startValue, ref Rect endValue, ref NoOptions options, in MotionEvaluationContext context)
         {
             var x = math.lerp(startValue.x, endValue.x, context.Progress);
             var y = math.lerp(startValue.y, endValue.y, context.Progress);

--- a/src/LitMotion/Assets/LitMotion/Runtime/IMotionAdapter.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/IMotionAdapter.cs
@@ -17,6 +17,6 @@ namespace LitMotion
         /// <param name="options">Option value to specify</param>
         /// <param name="context">Animation context</param>
         /// <returns>Current value</returns>
-        TValue Evaluate(in TValue startValue, in TValue endValue, in TOptions options, in MotionEvaluationContext context);
+        TValue Evaluate(ref TValue startValue, ref TValue endValue, ref TOptions options, in MotionEvaluationContext context);
     }
 }

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionStorage.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionStorage.cs
@@ -215,7 +215,7 @@ namespace LitMotion
                 RemoveAt(entries[entryIndexes[i]].DenseIndex);
             }
 
-            //Avoid Memory leak
+            // Avoid Memory leak
             lastCallbacksSpan[tail..].Clear();
             entryIndexes.Dispose();
         }
@@ -240,7 +240,7 @@ namespace LitMotion
                 throw new ArgumentException("Motion has been destroyed or no longer exists.");
             }
 
-            var motion = dataArray[denseIndex];
+            ref var motion = ref GetDataSpan()[denseIndex];
             var version = entry.Version;
             if (version <= 0 || version != handle.Version || motion.Status == MotionStatus.None)
             {
@@ -248,7 +248,6 @@ namespace LitMotion
             }
 
             motion.Status = MotionStatus.Canceled;
-            dataArray[denseIndex] = motion;
 
 #if LITMOTION_SUPPORT_UNITASK
             callbacksArray[denseIndex].UniTaskConfiguredSource?.OnMotionCanceled();
@@ -264,7 +263,7 @@ namespace LitMotion
                 throw new ArgumentException("Motion has been destroyed or no longer exists.");
             }
 
-            var motion = dataArray[denseIndex];
+            ref var motion = ref GetDataSpan()[denseIndex];
             var version = entry.Version;
             if (version <= 0 || version != handle.Version || motion.Status == MotionStatus.None)
             {
@@ -286,7 +285,6 @@ namespace LitMotion
 
             // To avoid duplication of Complete processing, it is treated as canceled internally.
             motion.Status = MotionStatus.Canceled;
-            dataArray[denseIndex] = motion;
 
             float endProgress = motion.LoopType switch
             {
@@ -296,9 +294,9 @@ namespace LitMotion
                 _ => 1f
             };
             var endValue = default(TAdapter).Evaluate(
-                motion.StartValue,
-                motion.EndValue,
-                motion.Options,
+                ref motion.StartValue,
+                ref motion.EndValue,
+                ref motion.Options,
                 new() { Progress = EaseUtility.Evaluate(endProgress, motion.Ease) }
             );
 

--- a/src/LitMotion/Assets/LitMotion/Runtime/MotionUpdateJob.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/MotionUpdateJob.cs
@@ -109,7 +109,7 @@ namespace LitMotion
                     Progress = progress
                 };
 
-                Output[index] = default(TAdapter).Evaluate(ptr->StartValue, ptr->EndValue, ptr->Options, context);
+                Output[index] = default(TAdapter).Evaluate(ref ptr->StartValue, ref ptr->EndValue, ref ptr->Options, context);
             }
             else if (ptr->Status is MotionStatus.Completed or MotionStatus.Canceled)
             {


### PR DESCRIPTION
Change the IMotionAdapter's Evaluate argument to ref to allow state management within the custom options. This is a breaking change.