### PR TITLE
LitMotion.Extensions depends on UIElements, Unity UI and Unity Audio

### DIFF
--- a/src/LitMotion/Assets/LitMotion/Runtime/Extensions/General/LitMotionAudioExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Extensions/General/LitMotionAudioExtensions.cs
@@ -1,3 +1,4 @@
+#if LITMOTION_SUPPORT_UNITY_AUDIO
 using UnityEngine;
 using UnityEngine.Audio;
 
@@ -69,3 +70,4 @@ namespace LitMotion.Extensions
         }
     }
 }
+#endif

--- a/src/LitMotion/Assets/LitMotion/Runtime/Extensions/LitMotion.Extensions.asmdef
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Extensions/LitMotion.Extensions.asmdef
@@ -29,6 +29,21 @@
             "name": "com.cysharp.zstring",
             "expression": "",
             "define": "LITMOTION_SUPPORT_ZSTRING"
+        },
+        {
+            "name": "com.unity.modules.uielements",
+            "expression": "",
+            "define": "LITMOTION_SUPPORT_UIELEMENTS"
+        },
+        {
+            "name": "com.unity.ugui",
+            "expression": "",
+            "define": "LITMOTION_SUPPORT_UGUI"
+        },
+        {
+            "name": "com.unity.modules.audio",
+            "expression": "",
+            "define": "LITMOTION_SUPPORT_UNITY_AUDIO"
         }
     ],
     "noEngineReferences": false

--- a/src/LitMotion/Assets/LitMotion/Runtime/Extensions/UIToolkit/LitMotionUIToolkitExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Extensions/UIToolkit/LitMotionUIToolkitExtensions.cs
@@ -1,3 +1,4 @@
+#if LITMOTION_SUPPORT_UIELEMENTS
 using Unity.Collections;
 using UnityEngine;
 using UnityEngine.UIElements;
@@ -795,3 +796,4 @@ namespace LitMotion.Extensions
         #endregion
     }
 }
+#endif

--- a/src/LitMotion/Assets/LitMotion/Runtime/Extensions/uGUI/LitMotionUGUIExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Extensions/uGUI/LitMotionUGUIExtensions.cs
@@ -1,3 +1,4 @@
+#if LITMOTION_SUPPORT_UGUI
 using UnityEngine;
 using UnityEngine.UI;
 using Unity.Collections;
@@ -396,3 +397,4 @@ namespace LitMotion.Extensions
         }
     }
 }
+#endif


### PR DESCRIPTION
Added `versionDefines` due to compile errors in `LitMotion.Extensions` when 
`com.unity.modules.uielements` , `com.unity.ugui` or `com.unity.modules.audio` are removed.