### PR TITLE
Use static anonymouse functions

### DIFF
--- a/src/LitMotion/Assets/LitMotion/Runtime/Extensions/General/LitMotionAudioExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Extensions/General/LitMotionAudioExtensions.cs
@@ -22,7 +22,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(audioSource);
-            return builder.BindWithState(audioSource, (x, target) =>
+            return builder.BindWithState(audioSource, static (x, target) =>
             {
                 target.volume = x;
             });
@@ -41,7 +41,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(audioSource);
-            return builder.BindWithState(audioSource, (x, target) =>
+            return builder.BindWithState(audioSource, static (x, target) =>
             {
                 target.pitch = x;
             });
@@ -60,9 +60,9 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(audioMixer);
-            return builder.BindWithState(audioMixer, (x, target) =>
+            return builder.BindWithState(audioMixer, name, static (x, target, n) =>
             {
-                target.SetFloat(name, x);
+                target.SetFloat(n, x);
             });
         }
     }

--- a/src/LitMotion/Assets/LitMotion/Runtime/Extensions/General/LitMotionMaterialExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Extensions/General/LitMotionMaterialExtensions.cs
@@ -20,9 +20,9 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(material);
-            return builder.BindWithState(material, (x, m) =>
+            return builder.BindWithState(material, name, static (x, m, n) =>
             {
-                m.SetFloat(name, x);
+                m.SetFloat(n, x);
             });
         }
 
@@ -58,9 +58,9 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<int, TOptions>
         {
             Error.IsNull(material);
-            return builder.BindWithState(material, (x, m) =>
+            return builder.BindWithState(material, name, static (x, m, n) =>
             {
-                m.SetInteger(name, x);
+                m.SetInteger(n, x);
             });
         }
 
@@ -96,9 +96,9 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Color, TOptions>
         {
             Error.IsNull(material);
-            return builder.BindWithState(material, (x, m) =>
+            return builder.BindWithState(material, name, static (x, m, n) =>
             {
-                m.SetColor(name, x);
+                m.SetColor(n, x);
             });
         }
 

--- a/src/LitMotion/Assets/LitMotion/Runtime/Extensions/General/LitMotionSpriteRendererExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Extensions/General/LitMotionSpriteRendererExtensions.cs
@@ -20,7 +20,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Color, TOptions>
         {
             Error.IsNull(spriteRenderer);
-            return builder.BindWithState(spriteRenderer, (x, m) =>
+            return builder.BindWithState(spriteRenderer, static (x, m) =>
             {
                 m.color = x;
             });
@@ -39,7 +39,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(spriteRenderer);
-            return builder.BindWithState(spriteRenderer, (x, m) =>
+            return builder.BindWithState(spriteRenderer, static (x, m) =>
             {
                 var c = m.color;
                 c.r = x;
@@ -60,7 +60,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(spriteRenderer);
-            return builder.BindWithState(spriteRenderer, (x, m) =>
+            return builder.BindWithState(spriteRenderer, static (x, m) =>
             {
                 var c = m.color;
                 c.g = x;
@@ -81,7 +81,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(spriteRenderer);
-            return builder.BindWithState(spriteRenderer, (x, m) =>
+            return builder.BindWithState(spriteRenderer, static (x, m) =>
             {
                 var c = m.color;
                 c.b = x;
@@ -102,7 +102,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(spriteRenderer);
-            return builder.BindWithState(spriteRenderer, (x, m) =>
+            return builder.BindWithState(spriteRenderer, static (x, m) =>
             {
                 var c = m.color;
                 c.a = x;

--- a/src/LitMotion/Assets/LitMotion/Runtime/Extensions/General/LitMotionTransformExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Extensions/General/LitMotionTransformExtensions.cs
@@ -20,7 +20,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector3, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, (x, t) =>
+            return builder.BindWithState(transform, static (x, t) =>
             {
                 t.position = x;
             });
@@ -39,7 +39,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, (x, t) =>
+            return builder.BindWithState(transform, static (x, t) =>
             {
                 var p = t.position;
                 p.x = x;
@@ -60,7 +60,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, (x, t) =>
+            return builder.BindWithState(transform, static (x, t) =>
             {
                 var p = t.position;
                 p.y = x;
@@ -81,7 +81,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, (x, t) =>
+            return builder.BindWithState(transform, static (x, t) =>
             {
                 var p = t.position;
                 p.z = x;
@@ -102,7 +102,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector3, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, (x, t) =>
+            return builder.BindWithState(transform, static (x, t) =>
             {
                 t.localPosition = x;
             });
@@ -121,7 +121,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, (x, t) =>
+            return builder.BindWithState(transform, static (x, t) =>
             {
                 var p = t.localPosition;
                 p.x = x;
@@ -143,7 +143,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, (x, t) =>
+            return builder.BindWithState(transform, static (x, t) =>
             {
                 var p = t.localPosition;
                 p.y = x;
@@ -164,7 +164,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, (x, t) =>
+            return builder.BindWithState(transform, static (x, t) =>
             {
                 var p = t.localPosition;
                 p.z = x;
@@ -185,7 +185,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Quaternion, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, (x, t) =>
+            return builder.BindWithState(transform, static (x, t) =>
             {
                 t.rotation = x;
             });
@@ -204,7 +204,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Quaternion, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, (x, t) =>
+            return builder.BindWithState(transform, static (x, t) =>
             {
                 t.localRotation = x;
             });
@@ -223,7 +223,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector3, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, (x, t) =>
+            return builder.BindWithState(transform, static (x, t) =>
             {
                 t.eulerAngles = x;
             });
@@ -242,7 +242,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, (x, t) =>
+            return builder.BindWithState(transform, static (x, t) =>
             {
                 var p = t.eulerAngles;
                 p.x = x;
@@ -263,7 +263,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, (x, t) =>
+            return builder.BindWithState(transform, static (x, t) =>
             {
                 var p = t.eulerAngles;
                 p.y = x;
@@ -284,7 +284,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, (x, t) =>
+            return builder.BindWithState(transform, static (x, t) =>
             {
                 var p = t.eulerAngles;
                 p.z = x;
@@ -305,7 +305,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector3, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, (x, t) =>
+            return builder.BindWithState(transform, static (x, t) =>
             {
                 t.localEulerAngles = x;
             });
@@ -324,7 +324,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, (x, t) =>
+            return builder.BindWithState(transform, static (x, t) =>
             {
                 var p = t.localEulerAngles;
                 p.x = x;
@@ -345,7 +345,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, (x, t) =>
+            return builder.BindWithState(transform, static (x, t) =>
             {
                 var p = t.localEulerAngles;
                 p.y = x;
@@ -366,7 +366,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, (x, t) =>
+            return builder.BindWithState(transform, static (x, t) =>
             {
                 var p = t.localEulerAngles;
                 p.z = x;
@@ -387,7 +387,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector3, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, (x, t) =>
+            return builder.BindWithState(transform, static (x, t) =>
             {
                 t.localScale = x;
             });
@@ -406,7 +406,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, (x, t) =>
+            return builder.BindWithState(transform, static (x, t) =>
             {
                 var p = t.localScale;
                 p.x = x;
@@ -427,7 +427,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, (x, t) =>
+            return builder.BindWithState(transform, static (x, t) =>
             {
                 var p = t.localScale;
                 p.y = x;
@@ -448,7 +448,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, (x, t) =>
+            return builder.BindWithState(transform, static (x, t) =>
             {
                 var p = t.localScale;
                 p.z = x;

--- a/src/LitMotion/Assets/LitMotion/Runtime/Extensions/TextMeshPro/LitMotionTextMeshProExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Extensions/TextMeshPro/LitMotionTextMeshProExtensions.cs
@@ -27,7 +27,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, (x, target) =>
+            return builder.BindWithState(text, static (x, target) =>
             {
                 target.fontSize = x;
             });
@@ -46,7 +46,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<int, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, (x, target) =>
+            return builder.BindWithState(text, static (x, target) =>
             {
                 target.maxVisibleCharacters = x;
             });
@@ -65,7 +65,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<int, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, (x, target) =>
+            return builder.BindWithState(text, static (x, target) =>
             {
                 target.maxVisibleLines = x;
             });
@@ -84,7 +84,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<int, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, (x, target) =>
+            return builder.BindWithState(text, static (x, target) =>
             {
                 target.maxVisibleWords = x;
             });
@@ -103,7 +103,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Color, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, (x, target) =>
+            return builder.BindWithState(text, static (x, target) =>
             {
                 target.color = x;
             });
@@ -122,7 +122,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, (x, target) =>
+            return builder.BindWithState(text, static (x, target) =>
             {
                 var c = target.color;
                 c.r = x;
@@ -143,7 +143,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, (x, target) =>
+            return builder.BindWithState(text, static (x, target) =>
             {
                 var c = target.color;
                 c.g = x;
@@ -164,7 +164,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, (x, target) =>
+            return builder.BindWithState(text, static (x, target) =>
             {
                 var c = target.color;
                 c.b = x;
@@ -185,7 +185,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, (x, target) =>
+            return builder.BindWithState(text, static (x, target) =>
             {
                 var c = target.color;
                 c.a = x;
@@ -209,7 +209,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<FixedString32Bytes, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, (x, target) =>
+            return builder.BindWithState(text, static (x, target) =>
             {
                 var enumerator = x.GetEnumerator();
                 var length = 0;
@@ -239,7 +239,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<FixedString64Bytes, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, (x, target) =>
+            return builder.BindWithState(text, static (x, target) =>
             {
                 var enumerator = x.GetEnumerator();
                 var length = 0;
@@ -269,7 +269,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<FixedString128Bytes, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, (x, target) =>
+            return builder.BindWithState(text, static (x, target) =>
             {
                 var enumerator = x.GetEnumerator();
                 var length = 0;
@@ -299,7 +299,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<FixedString512Bytes, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, (x, target) =>
+            return builder.BindWithState(text, static (x, target) =>
             {
                 var enumerator = x.GetEnumerator();
                 var length = 0;
@@ -329,7 +329,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<FixedString4096Bytes, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, (x, target) =>
+            return builder.BindWithState(text, static (x, target) =>
             {
                 var enumerator = x.GetEnumerator();
                 var length = 0;
@@ -358,7 +358,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<int, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, (x, target) =>
+            return builder.BindWithState(text, static (x, target) =>
             {
 
                 var buffer = ArrayPool<char>.Shared.Rent(128);
@@ -383,7 +383,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<int, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, format, (x, target, format) =>
+            return builder.BindWithState(text, format, static (x, target, format) =>
             {
 #if LITMOTION_SUPPORT_ZSTRING
                 target.SetTextFormat(format, x);
@@ -408,7 +408,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<long, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, (x, target) =>
+            return builder.BindWithState(text, static (x, target) =>
             {
 
                 var buffer = ArrayPool<char>.Shared.Rent(128);
@@ -433,7 +433,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<long, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, format, (x, target, format) =>
+            return builder.BindWithState(text, format, static (x, target, format) =>
             {
 #if LITMOTION_SUPPORT_ZSTRING
                 target.SetTextFormat(format, x);
@@ -459,7 +459,7 @@ namespace LitMotion.Extensions
         {
             const string format = "{0}";
             Error.IsNull(text);
-            return builder.BindWithState(text, (x, target) =>
+            return builder.BindWithState(text, static (x, target) =>
             {
 #if LITMOTION_SUPPORT_ZSTRING
                 target.SetTextFormat(format, x);
@@ -483,7 +483,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, format, (x, target, format) =>
+            return builder.BindWithState(text, format, static (x, target, format) =>
             {
 #if LITMOTION_SUPPORT_ZSTRING
                 target.SetTextFormat(format, x);

--- a/src/LitMotion/Assets/LitMotion/Runtime/Extensions/UIToolkit/LitMotionUIToolkitExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Extensions/UIToolkit/LitMotionUIToolkitExtensions.cs
@@ -28,7 +28,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, (x, target) =>
+            return builder.BindWithState(visualElement, static (x, target) =>
             {
                 target.style.left = x;
             });
@@ -47,7 +47,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, (x, target) =>
+            return builder.BindWithState(visualElement, static (x, target) =>
             {
                 target.style.right = x;
             });
@@ -66,7 +66,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, (x, target) =>
+            return builder.BindWithState(visualElement, static (x, target) =>
             {
                 target.style.top = x;
             });
@@ -85,7 +85,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, (x, target) =>
+            return builder.BindWithState(visualElement, static (x, target) =>
             {
                 target.style.bottom = x;
             });
@@ -104,7 +104,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, (x, target) =>
+            return builder.BindWithState(visualElement, static (x, target) =>
             {
                 target.style.width = x;
             });
@@ -123,7 +123,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, (x, target) =>
+            return builder.BindWithState(visualElement, static (x, target) =>
             {
                 target.style.height = x;
             });
@@ -142,7 +142,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Color, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, (x, target) =>
+            return builder.BindWithState(visualElement, static (x, target) =>
             {
                 target.style.color = x;
             });
@@ -161,7 +161,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, (x, target) =>
+            return builder.BindWithState(visualElement, static (x, target) =>
             {
                 var c = target.style.color.value;
                 c.r = x;
@@ -182,7 +182,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, (x, target) =>
+            return builder.BindWithState(visualElement, static (x, target) =>
             {
                 var c = target.style.color.value;
                 c.g = x;
@@ -203,7 +203,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, (x, target) =>
+            return builder.BindWithState(visualElement, static (x, target) =>
             {
                 var c = target.style.color.value;
                 c.b = x;
@@ -224,7 +224,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, (x, target) =>
+            return builder.BindWithState(visualElement, static (x, target) =>
             {
                 var c = target.style.color.value;
                 c.a = x;
@@ -245,7 +245,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Color, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, (x, target) =>
+            return builder.BindWithState(visualElement, static (x, target) =>
             {
                 target.style.backgroundColor = x;
             });
@@ -264,7 +264,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, (x, target) =>
+            return builder.BindWithState(visualElement, static (x, target) =>
             {
                 var c = target.style.backgroundColor.value;
                 c.r = x;
@@ -285,7 +285,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, (x, target) =>
+            return builder.BindWithState(visualElement, static (x, target) =>
             {
                 var c = target.style.backgroundColor.value;
                 c.g = x;
@@ -306,7 +306,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, (x, target) =>
+            return builder.BindWithState(visualElement, static (x, target) =>
             {
                 var c = target.style.backgroundColor.value;
                 c.b = x;
@@ -327,7 +327,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, (x, target) =>
+            return builder.BindWithState(visualElement, static (x, target) =>
             {
                 var c = target.style.backgroundColor.value;
                 c.a = x;
@@ -348,7 +348,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, (x, target) =>
+            return builder.BindWithState(visualElement, static (x, target) =>
             {
                 target.style.opacity = x;
             });
@@ -367,7 +367,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, (x, target) =>
+            return builder.BindWithState(visualElement, static (x, target) =>
             {
                 target.style.fontSize = x;
             });
@@ -386,7 +386,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, (x, target) =>
+            return builder.BindWithState(visualElement, static (x, target) =>
             {
                 target.style.wordSpacing = x;
             });
@@ -405,7 +405,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector3, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, (x, target) =>
+            return builder.BindWithState(visualElement, static (x, target) =>
             {
                 target.style.translate = new Translate(x.x, x.y, x.z);
             });
@@ -424,7 +424,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, (x, target) =>
+            return builder.BindWithState(visualElement, static (x, target) =>
             {
                 target.style.translate = new Translate(x.x, x.y);
             });
@@ -462,7 +462,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector3, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, (x, target) =>
+            return builder.BindWithState(visualElement, static (x, target) =>
             {
                 target.style.scale = new Scale(x);
             });
@@ -481,7 +481,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector3, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, (x, target) =>
+            return builder.BindWithState(visualElement, static (x, target) =>
             {
                 target.style.transformOrigin = new TransformOrigin(x.x, x.y, x.z);
             });
@@ -500,7 +500,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, (x, target) =>
+            return builder.BindWithState(visualElement, static (x, target) =>
             {
                 target.style.transformOrigin = new TransformOrigin(x.x, x.y);
             });
@@ -523,7 +523,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(progressBar);
-            return builder.BindWithState(progressBar, (x, target) =>
+            return builder.BindWithState(progressBar, static (x, target) =>
             {
                 target.value = x;
             });
@@ -546,7 +546,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<FixedString32Bytes, TOptions>
         {
             Error.IsNull(textElement);
-            return builder.BindWithState(textElement, (x, target) =>
+            return builder.BindWithState(textElement, static (x, target) =>
             {
                 target.text = x.ConvertToString();
             });
@@ -565,7 +565,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<FixedString64Bytes, TOptions>
         {
             Error.IsNull(textElement);
-            return builder.BindWithState(textElement, (x, target) =>
+            return builder.BindWithState(textElement, static (x, target) =>
             {
                 target.text = x.ConvertToString();
             });
@@ -584,7 +584,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<FixedString128Bytes, TOptions>
         {
             Error.IsNull(textElement);
-            return builder.BindWithState(textElement, (x, target) =>
+            return builder.BindWithState(textElement, static (x, target) =>
             {
                 target.text = x.ConvertToString();
             });
@@ -603,7 +603,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<FixedString512Bytes, TOptions>
         {
             Error.IsNull(textElement);
-            return builder.BindWithState(textElement, (x, target) =>
+            return builder.BindWithState(textElement, static (x, target) =>
             {
                 target.text = x.ConvertToString();
             });
@@ -622,7 +622,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<FixedString4096Bytes, TOptions>
         {
             Error.IsNull(textElement);
-            return builder.BindWithState(textElement, (x, target) =>
+            return builder.BindWithState(textElement, static (x, target) =>
             {
                 target.text = x.ConvertToString();
             });
@@ -641,7 +641,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<int, TOptions>
         {
             Error.IsNull(textElement);
-            return builder.BindWithState(textElement, (x, target) =>
+            return builder.BindWithState(textElement, static (x, target) =>
             {
                 target.text = x.ToString();
             });
@@ -661,12 +661,12 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<int, TOptions>
         {
             Error.IsNull(textElement);
-            return builder.BindWithState(textElement, format, (x, target, foramt) =>
+            return builder.BindWithState(textElement, format, static (x, target, f) =>
             {
 #if LITMOTION_SUPPORT_ZSTRING
-                target.text = ZString.Format(format, x);
+                target.text = ZString.Format(f, x);
 #else
-                target.text = string.Format(format, x);
+                target.text = string.Format(f, x);
 #endif
             });
         }
@@ -684,7 +684,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<long, TOptions>
         {
             Error.IsNull(textElement);
-            return builder.BindWithState(textElement, (x, target) =>
+            return builder.BindWithState(textElement, static (x, target) =>
             {
                 target.text = x.ToString();
             });
@@ -704,7 +704,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<long, TOptions>
         {
             Error.IsNull(textElement);
-            return builder.BindWithState(textElement, format, (x, target, format) =>
+            return builder.BindWithState(textElement, format, static (x, target, format) =>
             {
 #if LITMOTION_SUPPORT_ZSTRING
                 target.text = ZString.Format(format, x);
@@ -727,7 +727,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(textElement);
-            return builder.BindWithState(textElement, (x, target) =>
+            return builder.BindWithState(textElement, static (x, target) =>
             {
                 target.text = x.ToString();
             });
@@ -747,7 +747,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(textElement);
-            return builder.BindWithState(textElement, format, (x, target, format) =>
+            return builder.BindWithState(textElement, format, static (x, target, format) =>
             {
 #if LITMOTION_SUPPORT_ZSTRING
                 target.text = ZString.Format(format, x);

--- a/src/LitMotion/Assets/LitMotion/Runtime/Extensions/VisualEffectGragh/LitMotionVisualEffectExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Extensions/VisualEffectGragh/LitMotionVisualEffectExtensions.cs
@@ -22,9 +22,9 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(visualEffect);
-            return builder.BindWithState(visualEffect, (x, target) =>
+            return builder.BindWithState(visualEffect, name, static (x, target, n) =>
             {
-                target.SetFloat(name, x);
+                target.SetFloat(n, x);
             });
         }
 
@@ -60,9 +60,9 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<int, TOptions>
         {
             Error.IsNull(visualEffect);
-            return builder.BindWithState(visualEffect, (x, target) =>
+            return builder.BindWithState(visualEffect, name, static (x, target, n) =>
             {
-                target.SetInt(name, x);
+                target.SetInt(n, x);
             });
         }
 
@@ -98,9 +98,9 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
         {
             Error.IsNull(visualEffect);
-            return builder.BindWithState(visualEffect, (x, target) =>
+            return builder.BindWithState(visualEffect, name, static (x, target, n) =>
             {
-                target.SetVector2(name, x);
+                target.SetVector2(n, x);
             });
         }
 
@@ -136,9 +136,9 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector3, TOptions>
         {
             Error.IsNull(visualEffect);
-            return builder.BindWithState(visualEffect, (x, target) =>
+            return builder.BindWithState(visualEffect, name, static (x, target, n) =>
             {
-                target.SetVector3(name, x);
+                target.SetVector3(n, x);
             });
         }
 
@@ -174,9 +174,9 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector4, TOptions>
         {
             Error.IsNull(visualEffect);
-            return builder.BindWithState(visualEffect, (x, target) =>
+            return builder.BindWithState(visualEffect, name, static (x, target, n) =>
             {
-                target.SetVector4(name, x);
+                target.SetVector4(n, x);
             });
         }
 

--- a/src/LitMotion/Assets/LitMotion/Runtime/Extensions/uGUI/LitMotionRectTransformExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Extensions/uGUI/LitMotionRectTransformExtensions.cs
@@ -20,7 +20,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
         {
             Error.IsNull(rectTransform);
-            return builder.BindWithState(rectTransform, (x, target) =>
+            return builder.BindWithState(rectTransform, static (x, target) =>
             {
                 target.anchoredPosition = x;
             });
@@ -39,7 +39,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(rectTransform);
-            return builder.BindWithState(rectTransform, (x, target) =>
+            return builder.BindWithState(rectTransform, static (x, target) =>
             {
                 var p = target.anchoredPosition;
                 p.x = x;
@@ -60,7 +60,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(rectTransform);
-            return builder.BindWithState(rectTransform, (x, target) =>
+            return builder.BindWithState(rectTransform, static (x, target) =>
             {
                 var p = target.anchoredPosition;
                 p.y = x;
@@ -81,7 +81,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector3, TOptions>
         {
             Error.IsNull(rectTransform);
-            return builder.BindWithState(rectTransform, (x, target) =>
+            return builder.BindWithState(rectTransform, static (x, target) =>
             {
                 target.anchoredPosition3D = x;
             });
@@ -100,7 +100,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(rectTransform);
-            return builder.BindWithState(rectTransform, (x, target) =>
+            return builder.BindWithState(rectTransform, static (x, target) =>
             {
                 var p = target.anchoredPosition3D;
                 p.x = x;
@@ -121,7 +121,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(rectTransform);
-            return builder.BindWithState(rectTransform, (x, target) =>
+            return builder.BindWithState(rectTransform, static (x, target) =>
             {
                 var p = target.anchoredPosition3D;
                 p.y = x;
@@ -142,7 +142,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(rectTransform);
-            return builder.BindWithState(rectTransform, (x, target) =>
+            return builder.BindWithState(rectTransform, static (x, target) =>
             {
                 var p = target.anchoredPosition3D;
                 p.z = x;
@@ -163,7 +163,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
         {
             Error.IsNull(rectTransform);
-            return builder.BindWithState(rectTransform, (x, target) =>
+            return builder.BindWithState(rectTransform, static (x, target) =>
             {
                 target.anchorMin = x;
             });
@@ -182,7 +182,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
         {
             Error.IsNull(rectTransform);
-            return builder.BindWithState(rectTransform, (x, target) =>
+            return builder.BindWithState(rectTransform, static (x, target) =>
             {
                 target.anchorMax = x;
             });
@@ -202,7 +202,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
         {
             Error.IsNull(rectTransform);
-            return builder.BindWithState(rectTransform, (x, target) =>
+            return builder.BindWithState(rectTransform, static (x, target) =>
             {
                 target.sizeDelta = x;
             });
@@ -221,7 +221,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(rectTransform);
-            return builder.BindWithState(rectTransform, (x, target) =>
+            return builder.BindWithState(rectTransform, static (x, target) =>
             {
                 var s = target.sizeDelta;
                 s.x = x;
@@ -242,7 +242,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(rectTransform);
-            return builder.BindWithState(rectTransform, (x, target) =>
+            return builder.BindWithState(rectTransform, static (x, target) =>
             {
                 var s = target.sizeDelta;
                 s.y = x;
@@ -263,7 +263,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
         {
             Error.IsNull(rectTransform);
-            return builder.BindWithState(rectTransform, (x, target) =>
+            return builder.BindWithState(rectTransform, static (x, target) =>
             {
                 target.pivot = x;
             });
@@ -282,7 +282,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(rectTransform);
-            return builder.BindWithState(rectTransform, (x, target) =>
+            return builder.BindWithState(rectTransform, static (x, target) =>
             {
                 var s = target.pivot;
                 s.x = x;
@@ -303,7 +303,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(rectTransform);
-            return builder.BindWithState(rectTransform, (x, target) =>
+            return builder.BindWithState(rectTransform, static (x, target) =>
             {
                 var s = target.pivot;
                 s.y = x;

--- a/src/LitMotion/Assets/LitMotion/Runtime/Extensions/uGUI/LitMotionUGUIExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Extensions/uGUI/LitMotionUGUIExtensions.cs
@@ -26,7 +26,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Color, TOptions>
         {
             Error.IsNull(graphic);
-            return builder.BindWithState(graphic, (x, target) =>
+            return builder.BindWithState(graphic, static (x, target) =>
             {
                 target.color = x;
             });
@@ -45,7 +45,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(graphic);
-            return builder.BindWithState(graphic, (x, target) =>
+            return builder.BindWithState(graphic, static (x, target) =>
             {
                 var c = target.color;
                 c.r = x;
@@ -66,7 +66,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(graphic);
-            return builder.BindWithState(graphic, (x, target) =>
+            return builder.BindWithState(graphic, static (x, target) =>
             {
                 var c = target.color;
                 c.g = x;
@@ -87,7 +87,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(graphic);
-            return builder.BindWithState(graphic, (x, target) =>
+            return builder.BindWithState(graphic, static (x, target) =>
             {
                 var c = target.color;
                 c.b = x;
@@ -108,7 +108,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(graphic);
-            return builder.BindWithState(graphic, (x, target) =>
+            return builder.BindWithState(graphic, static (x, target) =>
             {
                 var c = target.color;
                 c.a = x;
@@ -129,7 +129,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(image);
-            return builder.BindWithState(image, (x, target) =>
+            return builder.BindWithState(image, static (x, target) =>
             {
                 target.fillAmount = x;
             });
@@ -148,7 +148,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<int, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, (x, target) =>
+            return builder.BindWithState(text, static (x, target) =>
             {
                 target.fontSize = x;
             });
@@ -167,7 +167,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<FixedString32Bytes, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, (x, target) =>
+            return builder.BindWithState(text, static (x, target) =>
             {
                 target.text = x.ConvertToString();
             });
@@ -186,7 +186,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<FixedString64Bytes, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, (x, target) =>
+            return builder.BindWithState(text, static (x, target) =>
             {
                 target.text = x.ConvertToString();
             });
@@ -205,7 +205,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<FixedString128Bytes, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, (x, target) =>
+            return builder.BindWithState(text, static (x, target) =>
             {
                 target.text = x.ConvertToString();
             });
@@ -224,7 +224,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<FixedString512Bytes, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, (x, target) =>
+            return builder.BindWithState(text, static (x, target) =>
             {
                 target.text = x.ConvertToString();
             });
@@ -243,7 +243,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<FixedString4096Bytes, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, (x, target) =>
+            return builder.BindWithState(text, static (x, target) =>
             {
                 target.text = x.ConvertToString();
             });
@@ -262,7 +262,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<int, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, (x, target) =>
+            return builder.BindWithState(text, static (x, target) =>
             {
                 target.text = x.ToString();
             });
@@ -282,7 +282,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<int, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, format, (x, target, format) =>
+            return builder.BindWithState(text, format, static (x, target, format) =>
             {
 #if LITMOTION_SUPPORT_ZSTRING
                 target.text = ZString.Format(format, x);
@@ -305,7 +305,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<long, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, (x, target) =>
+            return builder.BindWithState(text, static (x, target) =>
             {
                 target.text = x.ToString();
             });
@@ -325,7 +325,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<long, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, format, (x, target, format) =>
+            return builder.BindWithState(text, format, static (x, target, format) =>
             {
 #if LITMOTION_SUPPORT_ZSTRING
                 target.text = ZString.Format(format, x);
@@ -348,7 +348,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, (x, target) =>
+            return builder.BindWithState(text, static (x, target) =>
             {
                 target.text = x.ToString();
             });
@@ -368,7 +368,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, format, (x, target, format) =>
+            return builder.BindWithState(text, format, static (x, target, format) =>
             {
 #if LITMOTION_SUPPORT_ZSTRING
                 target.text = ZString.Format(format, x);

--- a/src/LitMotion/Assets/LitMotion/Runtime/External/UniRx/LitMotionUniRxExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/External/UniRx/LitMotionUniRxExtensions.cs
@@ -23,7 +23,7 @@ namespace LitMotion
             where TAdapter : unmanaged, IMotionAdapter<TValue, TOptions>
         {
             var subject = new Subject<TValue>();
-            var callbacks = builder.BuildCallbackData(subject, (x, subject) => subject.OnNext(x));
+            var callbacks = builder.BuildCallbackData(subject, static (x, subject) => subject.OnNext(x));
             callbacks.OnCompleteAction += () => subject.OnCompleted();
             callbacks.OnCancelAction += () => subject.OnCompleted();
             var scheduler = builder.buffer.Scheduler;
@@ -48,7 +48,7 @@ namespace LitMotion
             where TAdapter : unmanaged, IMotionAdapter<TValue, TOptions>
         {
             Error.IsNull(reactiveProperty);
-            return builder.BindWithState(reactiveProperty, (x, target) =>
+            return builder.BindWithState(reactiveProperty, static (x, target) =>
             {
                 target.Value = x;
             });

--- a/src/LitMotion/Assets/LitMotion/Runtime/External/UniTask/LitMotionUniTaskExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/External/UniTask/LitMotionUniTaskExtensions.cs
@@ -42,7 +42,7 @@ namespace LitMotion
             where TAdapter : unmanaged, IMotionAdapter<TValue, TOptions>
         {
             Error.IsNull(reactiveProperty);
-            return builder.BindWithState(reactiveProperty, (x, target) =>
+            return builder.BindWithState(reactiveProperty, static (x, target) =>
             {
                 target.Value = x;
             });
@@ -113,7 +113,7 @@ namespace LitMotion
 
             if (cancellationToken.CanBeCanceled)
             {
-                result.cancellationRegistration = cancellationToken.RegisterWithoutCaptureExecutionContext(x =>
+                result.cancellationRegistration = cancellationToken.RegisterWithoutCaptureExecutionContext(static x =>
                 {
                     var source = (MotionConfiguredSource)x;
                     var motionHandle = source.motionHandle;

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/PlayerLoopHelper.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/PlayerLoopHelper.cs
@@ -58,15 +58,15 @@ namespace LitMotion
         {
             initialized = true;
             var newLoop = playerLoop.subSystemList.ToArray();
-            
-            InsertLoop(newLoop, typeof(PlayerLoopType.Initialization), typeof(LitMotionLoopRunners.LitMotionInitialization), () => MotionDispatcher.Update(PlayerLoopTiming.Initialization));
-            InsertLoop(newLoop, typeof(PlayerLoopType.EarlyUpdate), typeof(LitMotionLoopRunners.LitMotionEarlyUpdate), () => MotionDispatcher.Update(PlayerLoopTiming.EarlyUpdate));
-            InsertLoop(newLoop, typeof(PlayerLoopType.FixedUpdate), typeof(LitMotionLoopRunners.LitMotionFixedUpdate), () => MotionDispatcher.Update(PlayerLoopTiming.FixedUpdate));
-            InsertLoop(newLoop, typeof(PlayerLoopType.PreUpdate), typeof(LitMotionLoopRunners.LitMotionPreUpdate), () => MotionDispatcher.Update(PlayerLoopTiming.PreUpdate));
-            InsertLoop(newLoop, typeof(PlayerLoopType.Update), typeof(LitMotionLoopRunners.LitMotionUpdate), () => MotionDispatcher.Update(PlayerLoopTiming.Update));
-            InsertLoop(newLoop, typeof(PlayerLoopType.PreLateUpdate), typeof(LitMotionLoopRunners.LitMotionPreLateUpdate), () => MotionDispatcher.Update(PlayerLoopTiming.PreLateUpdate));
-            InsertLoop(newLoop, typeof(PlayerLoopType.PostLateUpdate), typeof(LitMotionLoopRunners.LitMotionPostLateUpdate), () => MotionDispatcher.Update(PlayerLoopTiming.PostLateUpdate));
-            InsertLoop(newLoop, typeof(PlayerLoopType.TimeUpdate), typeof(LitMotionLoopRunners.LitMotionTimeUpdate), () => MotionDispatcher.Update(PlayerLoopTiming.TimeUpdate));
+
+            InsertLoop(newLoop, typeof(PlayerLoopType.Initialization), typeof(LitMotionLoopRunners.LitMotionInitialization), static () => MotionDispatcher.Update(PlayerLoopTiming.Initialization));
+            InsertLoop(newLoop, typeof(PlayerLoopType.EarlyUpdate), typeof(LitMotionLoopRunners.LitMotionEarlyUpdate), static () => MotionDispatcher.Update(PlayerLoopTiming.EarlyUpdate));
+            InsertLoop(newLoop, typeof(PlayerLoopType.FixedUpdate), typeof(LitMotionLoopRunners.LitMotionFixedUpdate), static () => MotionDispatcher.Update(PlayerLoopTiming.FixedUpdate));
+            InsertLoop(newLoop, typeof(PlayerLoopType.PreUpdate), typeof(LitMotionLoopRunners.LitMotionPreUpdate), static () => MotionDispatcher.Update(PlayerLoopTiming.PreUpdate));
+            InsertLoop(newLoop, typeof(PlayerLoopType.Update), typeof(LitMotionLoopRunners.LitMotionUpdate), static () => MotionDispatcher.Update(PlayerLoopTiming.Update));
+            InsertLoop(newLoop, typeof(PlayerLoopType.PreLateUpdate), typeof(LitMotionLoopRunners.LitMotionPreLateUpdate), static () => MotionDispatcher.Update(PlayerLoopTiming.PreLateUpdate));
+            InsertLoop(newLoop, typeof(PlayerLoopType.PostLateUpdate), typeof(LitMotionLoopRunners.LitMotionPostLateUpdate), static () => MotionDispatcher.Update(PlayerLoopTiming.PostLateUpdate));
+            InsertLoop(newLoop, typeof(PlayerLoopType.TimeUpdate), typeof(LitMotionLoopRunners.LitMotionTimeUpdate), static () => MotionDispatcher.Update(PlayerLoopTiming.TimeUpdate));
 
             playerLoop.subSystemList = newLoop;
             PlayerLoop.SetPlayerLoop(playerLoop);

--- a/src/LitMotion/Assets/LitMotion/Runtime/MotionBuilderExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/MotionBuilderExtensions.cs
@@ -24,7 +24,7 @@ namespace LitMotion
             where TAdapter : unmanaged, IMotionAdapter<TValue, TOptions>
         {
             Error.IsNull(progress);
-            return builder.BindWithState(progress, (x, progress) => progress.Report(x));
+            return builder.BindWithState(progress, static (x, progress) => progress.Report(x));
         }
 
         /// <summary>
@@ -40,7 +40,7 @@ namespace LitMotion
             where TOptions : unmanaged, IMotionOptions
             where TAdapter : unmanaged, IMotionAdapter<TValue, TOptions>
         {
-            return builder.Bind(x => Debug.unityLogger.Log(x));
+            return builder.Bind(static x => Debug.unityLogger.Log(x));
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace LitMotion
             where TAdapter : unmanaged, IMotionAdapter<TValue, TOptions>
         {
             Error.IsNull(logger);
-            return builder.BindWithState(logger, (x, logger) => logger.Log(x));
+            return builder.BindWithState(logger, static (x, logger) => logger.Log(x));
         }
 
         /// <summary>


### PR DESCRIPTION
Modified the code to use static anonymous functions to prevent unintended captures.

Additionally, this ensures that optimizations for static anonymous functions are applied consistently across different environments.

- Some anonymous functions could not be made `static` as the state passed to `BindWithState` must be a reference type.
- Static anonymous functions are supported starting from [Unity 2021.2](https://unity.com/releases/editor/whats-new/2021.2.0)