### PR TITLE
Support R3

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The full version of documentation can be found [here](https://annulusgames.githu
 - Character animation for TextMeshPro text.
 - Motion Tracker Window for monitoring motions in progress.
 - Convert to Observables using UniRx.
+- Convert to Observables using R3.
 - Supports async/await via UniTask.
 - Extend types using `IMotionOptions` and `IMotionAdapter`.
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -31,6 +31,7 @@ LitMotionは[Magic Tween](https://github.com/AnnulusGames/MagicTween)に続い�
 - TextMeshProのテキストを文字ごとにアニメーション可能
 - MotionTrackerウィンドウによる動作中のモーションの追跡
 - UniRxを利用したObservableへの変換
+- R3を利用したObservableへの変換
 - UniTaskを利用したasync/await対応
 - `IMotionOptions`と`IMotionAdapter`を用いた型の拡張
 

--- a/docs/articles/en/integration-r3.md
+++ b/docs/articles/en/integration-r3.md
@@ -1,0 +1,28 @@
+# R3
+
+By integrating [R3](https://github.com/Cysharp/R3) into your project, it adds extension methods compatible with Reactive Extensions (Rx).
+
+If you have installed R3 via the Package Manager, the following functionality will be automatically added. However, if you have imported UniRx via a unitypackage or similar method, you'll need to add `LITMOTION_SUPPORT_R3` to `Settings > Player > Scripting Define Symbols`.
+
+### Creating Motion as an Observable
+
+You can create motion as an `IObservable<T>` using the `ToObservable()` method:
+
+```cs
+var observable = LMotion.Create(0f, 5f, 2f).ToObservable();
+observable.Subscribe(x =>
+{
+    Debug.Log(x);
+})
+.AddTo(gameObject);
+```
+
+### Binding to ReactiveProperty
+
+There's a provided extension method to bind the created motion to a `ReactiveProperty<T>`:
+
+```cs
+var reactiveProperty = new ReactiveProperty<float>();
+LMotion.Create(0f, 10f, 2f)
+    .BindToReactiveProperty(reactiveProperty);
+```

--- a/docs/articles/en/integration-unirx.md
+++ b/docs/articles/en/integration-unirx.md
@@ -2,7 +2,7 @@
 
 By integrating [UniRx](https://github.com/neuecc/UniRx) into your project, it adds extension methods compatible with Reactive Extensions (Rx).
 
-If you have installed UniRx via the Package Manager, the following functionality will be automatically added. However, if you have imported UniRx via a unitypackage or similar method, you'll need to add `LITMOTION_UNIRX_SUPPORT` to `Settings > Player > Scripting Define Symbols`.
+If you have installed UniRx via the Package Manager, the following functionality will be automatically added. However, if you have imported UniRx via a unitypackage or similar method, you'll need to add `LITMOTION_SUPPORT_UNIRX` to `Settings > Player > Scripting Define Symbols`.
 
 ### Creating Motion as an Observable
 

--- a/docs/articles/en/integration-unitask.md
+++ b/docs/articles/en/integration-unitask.md
@@ -2,7 +2,7 @@
 
 Introducing [UniTask](https://github.com/Cysharp/UniTask) into your project adds extension methods that allow motion waiting to be compatible with async/await.
 
-If you have installed UniTask via the Package Manager, the following functionality will be automatically added. However, if you have imported UniTask via a unitypackage or similar method, you'll need to add `LITMOTION_UNITASK_SUPPORT` to `Settings > Player > Scripting Define Symbols`.
+If you have installed UniTask via the Package Manager, the following functionality will be automatically added. However, if you have imported UniTask via a unitypackage or similar method, you'll need to add `LITMOTION_SUPPORT_UNITASK` to `Settings > Player > Scripting Define Symbols`.
 
 ### Waiting for Motion
 

--- a/docs/articles/en/toc.yml
+++ b/docs/articles/en/toc.yml
@@ -47,6 +47,8 @@
   href: motion-tracker.md
 
 - name: Integrations
+- name: R3
+  href: integration-r3.md
 - name: UniRx
   href: integration-unirx.md
 - name: UniTask

--- a/docs/articles/ja/integration-r3.md
+++ b/docs/articles/ja/integration-r3.md
@@ -1,0 +1,28 @@
+# R3
+
+プロジェクトに[R3](https://github.com/Cysharp/R3)を導入することでReactive Extensions(Rx)に対応した拡張メソッドが追加されます。
+
+R3をPackage Managerから導入した場合は自動で以下の機能が追加されます。unitypackage等で導入した場合は、`Project Settings > Player > Scripting Define Symbols`に`LITMOTION_SUPPORT_R3`を追加する必要があります。
+
+### モーションをObservableとして作成
+
+`ToObservable()`を使用することで、モーションを`IObservable<T>`として作成できます。
+
+```cs
+var observable = LMotion.Create(0f, 5f, 2f).ToObservable();
+observable.Subscribe(x =>
+{
+    Debug.Log(x);
+})
+.AddTo(gameObject);
+```
+
+### ReactivePropertyへバインド
+
+作成したモーションを`ReactiveProperty<T>`にバインドする拡張メソッドが用意されています。
+
+```cs
+var reactiveProperty = new ReactiveProperty<float>();
+LMotion.Create(0f, 10f, 2f)
+    .BindToReactiveProperty(reactiveProperty);
+```

--- a/docs/articles/ja/integration-unirx.md
+++ b/docs/articles/ja/integration-unirx.md
@@ -2,7 +2,7 @@
 
 プロジェクトに[UniRx](https://github.com/neuecc/UniRx)を導入することでReactive Extensions(Rx)に対応した拡張メソッドが追加されます。
 
-UniRxをPackage Managerから導入した場合は自動で以下の機能が追加されます。unitypackage等で導入した場合は、`Project Settings > Player > Scripting Define Symbols`に`LITMOTION_UNIRX_SUPPORT`を追加する必要があります。
+UniRxをPackage Managerから導入した場合は自動で以下の機能が追加されます。unitypackage等で導入した場合は、`Project Settings > Player > Scripting Define Symbols`に`LITMOTION_SUPPORT_UNIRX`を追加する必要があります。
 
 ### モーションをObservableとして作成
 

--- a/docs/articles/ja/integration-unitask.md
+++ b/docs/articles/ja/integration-unitask.md
@@ -2,7 +2,7 @@
 
 プロジェクトに[UniTask](https://github.com/Cysharp/UniTask)を導入することで、モーションの待機をasync/awaitに対応させる拡張メソッドが追加されます。
 
-UniTaskをPackage Managerから導入した場合は自動で以下の機能が追加されます。unitypackage等で導入した場合は、`Project Settings > Player > Scripting Define Symbols`に`LITMOTION_UNITASK_SUPPORT`を追加する必要があります。
+UniTaskをPackage Managerから導入した場合は自動で以下の機能が追加されます。unitypackage等で導入した場合は、`Project Settings > Player > Scripting Define Symbols`に`LITMOTION_SUPPORT_UNITASK`を追加する必要があります。
 
 ### モーションの待機
 

--- a/docs/articles/ja/toc.yml
+++ b/docs/articles/ja/toc.yml
@@ -47,6 +47,8 @@
   href: motion-tracker.md
 
 - name: Integrations
+- name: R3
+  href: integration-r3.md
 - name: UniRx
   href: integration-unirx.md
 - name: UniTask

--- a/src/LitMotion/Assets/LitMotion/Runtime/External/R3.meta
+++ b/src/LitMotion/Assets/LitMotion/Runtime/External/R3.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8e2e973abce4a31438b6901111ed7a03
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/LitMotion/Assets/LitMotion/Runtime/External/R3/LitMotionR3Extensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/External/R3/LitMotionR3Extensions.cs
@@ -1,0 +1,54 @@
+#if LITMOTION_SUPPORT_R3
+using R3;
+
+namespace LitMotion
+{
+    public static class LitMotionR3Extensions
+    {
+        /// <summary>
+        /// Create the motion as Observable.
+        /// </summary>
+        /// <typeparam name="TValue">The type of value to animate</typeparam>
+        /// <typeparam name="TOptions">The type of special parameters given to the motion data</typeparam>
+        /// <typeparam name="TAdapter">The type of adapter that support value animation</typeparam>
+        /// <param name="builder">This builder</param>
+        /// <returns>Observable of the created motion.</returns>
+        public static Observable<TValue> ToObservable<TValue, TOptions, TAdapter>(this MotionBuilder<TValue, TOptions, TAdapter> builder)
+            where TValue : unmanaged
+            where TOptions : unmanaged, IMotionOptions
+            where TAdapter : unmanaged, IMotionAdapter<TValue, TOptions>
+        {
+            var subject = new Subject<TValue>();
+            var callbacks = builder.BuildCallbackData(subject, static (x, subject) => subject.OnNext(x));
+            callbacks.OnCompleteAction += () => subject.OnCompleted();
+            callbacks.OnCancelAction += () => subject.OnCompleted();
+            var scheduler = builder.buffer.Scheduler;
+            var entity = builder.BuildMotionData();
+
+            builder.Schedule(scheduler, ref entity, ref callbacks);
+            return subject;
+        }
+
+        /// <summary>
+        /// Create a motion data and bind it to ReactiveProperty.
+        /// </summary>
+        /// <typeparam name="TValue">The type of value to animate</typeparam>
+        /// <typeparam name="TOptions">The type of special parameters given to the motion data</typeparam>
+        /// <typeparam name="TAdapter">The type of adapter that support value animation</typeparam>
+        /// <param name="builder">This builder</param>
+        /// <param name="progress">Target object that implements IProgress</param>
+        /// <returns>Handle of the created motion data.</returns>
+        public static MotionHandle BindToReactiveProperty<TValue, TOptions, TAdapter>(this MotionBuilder<TValue, TOptions, TAdapter> builder, ReactiveProperty<TValue> reactiveProperty)
+            where TValue : unmanaged
+            where TOptions : unmanaged, IMotionOptions
+            where TAdapter : unmanaged, IMotionAdapter<TValue, TOptions>
+        {
+            Error.IsNull(reactiveProperty);
+            return builder.BindWithState(reactiveProperty, static (x, target) =>
+            {
+                target.Value = x;
+            });
+        }
+    }
+}
+#endif

--- a/src/LitMotion/Assets/LitMotion/Runtime/External/R3/LitMotionR3Extensions.cs.meta
+++ b/src/LitMotion/Assets/LitMotion/Runtime/External/R3/LitMotionR3Extensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 78c4cfe16961d754ca0e1cd47cf6cccf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/LitMotion/Assets/LitMotion/Runtime/LitMotion.asmdef
+++ b/src/LitMotion/Assets/LitMotion/Runtime/LitMotion.asmdef
@@ -26,6 +26,16 @@
             "name": "com.neuecc.unirx",
             "expression": "",
             "define": "LITMOTION_SUPPORT_UNIRX"
+        },
+        {
+            "name": "com.cysharp.r3",
+            "expression": "",
+            "define": "LITMOTION_SUPPORT_R3"
+        },
+        {
+            "name": "org.nuget.r3",
+            "expression": "",
+            "define": "LITMOTION_SUPPORT_R3"
         }
     ],
     "noEngineReferences": false

--- a/src/LitMotion/Assets/LitMotion/Tests/Runtime/ExternalExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Tests/Runtime/ExternalExtensions.cs
@@ -1,0 +1,25 @@
+﻿namespace LitMotion.Tests.Runtime
+{
+    static class ExternalExtensions
+    {
+#if LITMOTION_TEST_R3
+        public static R3.Observable<TValue> ToR3Observable<TValue, TOptions, TAdapter>(this MotionBuilder<TValue, TOptions, TAdapter> builder)
+            where TValue : unmanaged
+            where TOptions : unmanaged, IMotionOptions
+            where TAdapter : unmanaged, IMotionAdapter<TValue, TOptions>
+        {
+            return LitMotionR3Extensions.ToObservable(builder);
+        }
+#endif
+
+#if LITMOTION_TEST_UNIRX
+        public static System.IObservable<TValue> ToRxObservable<TValue, TOptions, TAdapter>(this MotionBuilder<TValue, TOptions, TAdapter> builder)
+            where TValue : unmanaged
+            where TOptions : unmanaged, IMotionOptions
+            where TAdapter : unmanaged, IMotionAdapter<TValue, TOptions>
+        {
+            return LitMotionUniRxExtensions.ToObservable(builder);
+        }
+#endif
+    }
+}

--- a/src/LitMotion/Assets/LitMotion/Tests/Runtime/ExternalExtensions.cs.meta
+++ b/src/LitMotion/Assets/LitMotion/Tests/Runtime/ExternalExtensions.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 850a216eea3a43c68cee68a9d3d41e7f
+timeCreated: 1707117147

--- a/src/LitMotion/Assets/LitMotion/Tests/Runtime/LitMotion.Tests.Runtime.asmdef
+++ b/src/LitMotion/Assets/LitMotion/Tests/Runtime/LitMotion.Tests.Runtime.asmdef
@@ -15,7 +15,8 @@
     "allowUnsafeCode": false,
     "overrideReferences": true,
     "precompiledReferences": [
-        "nunit.framework.dll"
+        "nunit.framework.dll",
+        "R3.dll"
     ],
     "autoReferenced": false,
     "defineConstraints": [
@@ -31,6 +32,11 @@
             "name": "com.neuecc.unirx",
             "expression": "",
             "define": "LITMOTION_TEST_UNIRX"
+        },
+        {
+            "name": "com.cysharp.r3",
+            "expression": "",
+            "define": "LITMOTION_TEST_R3"
         }
     ],
     "noEngineReferences": false

--- a/src/LitMotion/Assets/LitMotion/Tests/Runtime/R3Test.cs
+++ b/src/LitMotion/Assets/LitMotion/Tests/Runtime/R3Test.cs
@@ -1,14 +1,14 @@
-#if LITMOTION_TEST_UNIRX
+﻿#if LITMOTION_TEST_R3
 using System;
 using System.Collections;
 using UnityEngine;
 using UnityEngine.TestTools;
-using UniRx;
+using R3;
 using NUnit.Framework;
 
 namespace LitMotion.Tests.Runtime
 {
-    public class UniRxTest
+    public class R3Test
     {
         readonly CompositeDisposable disposables = new();
 
@@ -24,7 +24,7 @@ namespace LitMotion.Tests.Runtime
             bool completed = false;
             LMotion.Create(0f, 10f, 2f)
                 .WithOnComplete(() => completed = true)
-                .ToRxObservable()
+                .ToR3Observable()
                 .Subscribe(x => Debug.Log(x))
                 .AddTo(disposables);
             while (!completed) yield return null;

--- a/src/LitMotion/Assets/LitMotion/Tests/Runtime/R3Test.cs.meta
+++ b/src/LitMotion/Assets/LitMotion/Tests/Runtime/R3Test.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a3294b2d86c549029554aab3acae47b7
+timeCreated: 1706465161

--- a/src/LitMotion/Packages/manifest.json
+++ b/src/LitMotion/Packages/manifest.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "com.cysharp.r3": "https://github.com/Cysharp/R3.git?path=src/R3.Unity/Assets/R3.Unity",
     "com.cysharp.unitask": "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask",
     "com.cysharp.zstring": "https://github.com/Cysharp/ZString.git?path=src/ZString.Unity/Assets/Scripts/ZString",
     "com.neuecc.unirx": "https://github.com/neuecc/UniRx.git?path=Assets/Plugins/UniRx/Scripts",
@@ -12,6 +13,10 @@
     "com.unity.ugui": "2.0.0",
     "com.unity.visualeffectgraph": "16.0.4",
     "com.unity.visualscripting": "1.8.0",
+    "org.nuget.microsoft.bcl.timeprovider": "8.0.1",
+    "org.nuget.r3": "0.1.21",
+    "org.nuget.system.componentmodel.annotations": "5.0.0",
+    "org.nuget.system.threading.channels": "8.0.0",
     "com.unity.modules.accessibility": "1.0.0",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",
@@ -44,5 +49,14 @@
     "com.unity.modules.vr": "1.0.0",
     "com.unity.modules.wind": "1.0.0",
     "com.unity.modules.xr": "1.0.0"
-  }
+  },
+  "scopedRegistries": [
+    {
+      "name": "Unity NuGet",
+      "url": "https://unitynuget-registry.azurewebsites.net",
+      "scopes": [
+        "org.nuget"
+      ]
+    }
+  ]
 }

--- a/src/LitMotion/Packages/manifest.json
+++ b/src/LitMotion/Packages/manifest.json
@@ -14,7 +14,7 @@
     "com.unity.visualeffectgraph": "16.0.4",
     "com.unity.visualscripting": "1.8.0",
     "org.nuget.microsoft.bcl.timeprovider": "8.0.1",
-    "org.nuget.r3": "0.1.21",
+    "org.nuget.r3": "1.1.10",
     "org.nuget.system.componentmodel.annotations": "5.0.0",
     "org.nuget.system.threading.channels": "8.0.0",
     "com.unity.modules.accessibility": "1.0.0",

--- a/src/LitMotion/Packages/packages-lock.json
+++ b/src/LitMotion/Packages/packages-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "com.unity.modules.imgui": "1.0.0"
       },
-      "hash": "3bf68621f9af5cacf5a1f1e2920a1f89a08b6c06"
+      "hash": "f0d7a6ee7f8a31dfeef3e25f120d4e2e55ecbdbe"
     },
     "com.cysharp.unitask": {
       "version": "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask",
@@ -285,7 +285,7 @@
       "url": "https://unitynuget-registry.azurewebsites.net"
     },
     "org.nuget.r3": {
-      "version": "0.1.21",
+      "version": "1.1.10",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/src/LitMotion/Packages/packages-lock.json
+++ b/src/LitMotion/Packages/packages-lock.json
@@ -1,5 +1,14 @@
 {
   "dependencies": {
+    "com.cysharp.r3": {
+      "version": "https://github.com/Cysharp/R3.git?path=src/R3.Unity/Assets/R3.Unity",
+      "depth": 0,
+      "source": "git",
+      "dependencies": {
+        "com.unity.modules.imgui": "1.0.0"
+      },
+      "hash": "3bf68621f9af5cacf5a1f1e2920a1f89a08b6c06"
+    },
     "com.cysharp.unitask": {
       "version": "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask",
       "depth": 0,
@@ -256,6 +265,95 @@
         "com.unity.modules.jsonserialize": "1.0.0"
       },
       "url": "https://packages.unity.com"
+    },
+    "org.nuget.microsoft.bcl.asyncinterfaces": {
+      "version": "8.0.0",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.system.threading.tasks.extensions": "4.5.4"
+      },
+      "url": "https://unitynuget-registry.azurewebsites.net"
+    },
+    "org.nuget.microsoft.bcl.timeprovider": {
+      "version": "8.0.1",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.microsoft.bcl.asyncinterfaces": "8.0.0"
+      },
+      "url": "https://unitynuget-registry.azurewebsites.net"
+    },
+    "org.nuget.r3": {
+      "version": "0.1.21",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.microsoft.bcl.timeprovider": "8.0.0",
+        "org.nuget.system.buffers": "4.5.1",
+        "org.nuget.system.componentmodel.annotations": "5.0.0",
+        "org.nuget.system.memory": "4.5.5",
+        "org.nuget.system.runtime.compilerservices.unsafe": "6.0.0",
+        "org.nuget.system.threading.channels": "8.0.0"
+      },
+      "url": "https://unitynuget-registry.azurewebsites.net"
+    },
+    "org.nuget.system.buffers": {
+      "version": "4.5.1",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://unitynuget-registry.azurewebsites.net"
+    },
+    "org.nuget.system.componentmodel.annotations": {
+      "version": "5.0.0",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://unitynuget-registry.azurewebsites.net"
+    },
+    "org.nuget.system.memory": {
+      "version": "4.5.5",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.system.buffers": "4.5.1",
+        "org.nuget.system.numerics.vectors": "4.4.0",
+        "org.nuget.system.runtime.compilerservices.unsafe": "4.5.3"
+      },
+      "url": "https://unitynuget-registry.azurewebsites.net"
+    },
+    "org.nuget.system.numerics.vectors": {
+      "version": "4.4.0",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://unitynuget-registry.azurewebsites.net"
+    },
+    "org.nuget.system.runtime.compilerservices.unsafe": {
+      "version": "6.0.0",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://unitynuget-registry.azurewebsites.net"
+    },
+    "org.nuget.system.threading.channels": {
+      "version": "8.0.0",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.system.threading.tasks.extensions": "4.5.4"
+      },
+      "url": "https://unitynuget-registry.azurewebsites.net"
+    },
+    "org.nuget.system.threading.tasks.extensions": {
+      "version": "4.5.4",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.system.runtime.compilerservices.unsafe": "4.5.3"
+      },
+      "url": "https://unitynuget-registry.azurewebsites.net"
     },
     "com.unity.modules.accessibility": {
       "version": "1.0.0",

--- a/src/LitMotion/ProjectSettings/PackageManagerSettings.asset
+++ b/src/LitMotion/ProjectSettings/PackageManagerSettings.asset
@@ -13,11 +13,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_EnablePreReleasePackages: 0
-  m_EnablePackageDependencies: 0
   m_AdvancedSettingsExpanded: 1
   m_ScopedRegistriesSettingsExpanded: 1
   m_SeeAllPackageVersions: 0
+  m_DismissPreviewPackagesInUse: 0
   oneTimeWarningShown: 0
+  oneTimeDeprecatedPopUpShown: 0
   m_Registries:
   - m_Id: main
     m_Name: 
@@ -25,11 +26,20 @@ MonoBehaviour:
     m_Scopes: []
     m_IsDefault: 1
     m_Capabilities: 7
-  m_UserSelectedRegistryName: 
+    m_ConfigSource: 0
+  - m_Id: scoped:project:Unity NuGet
+    m_Name: Unity NuGet
+    m_Url: https://unitynuget-registry.azurewebsites.net
+    m_Scopes:
+    - org.nuget
+    m_IsDefault: 0
+    m_Capabilities: 0
+    m_ConfigSource: 4
+  m_UserSelectedRegistryName: Unity NuGet
   m_UserAddingNewScopedRegistry: 0
   m_RegistryInfoDraft:
     m_Modified: 0
     m_ErrorMessage: 
-    m_UserModificationsInstanceId: -830
-    m_OriginalInstanceId: -832
+    m_UserModificationsInstanceId: -852
+    m_OriginalInstanceId: -854
   m_LoadAssets: 0


### PR DESCRIPTION
UniRxと同様にR3サポートを追加します。

直接依存するのはR3.dllのみですがアセンブリ定義内のバージョン定義を利用できないので[UnityNuGet](https://github.com/xoofx/UnityNuGet)をScoped Registriesに追加してupm経由でR3をインストールして `org.nuget.r3` が存在する時に `LITMOTION_SUPPORT_R3` を設定します。また、R3.UnityがインストールされているならR3.dllも導入済みであるはずなので `com.cysharp.r3` が存在する場合も同様に `LITMOTION_SUPPORT_R3` を定義しています。

また、LitMotionR3Extension.cs に追加した拡張メソッドは LitMotionRxExtension.cs の拡張メソッドとシグネチャが同じで区別できないので別名定義して呼び分けできるようにした拡張メソッドを ExternalExtensions.cs で定義してテストから利用しています。

UniRxとUniTaskのドキュメントでScripting Define Symbolsの値がコードと異なっていたので修正しています。