### PR TITLE
Change: FastListCore initialization to be lazy

### DIFF
--- a/src/LitMotion/Assets/LitMotion/Runtime/Extensions/TextMeshPro/TextMeshProMotionAnimator.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Extensions/TextMeshPro/TextMeshProMotionAnimator.cs
@@ -175,7 +175,7 @@ namespace LitMotion.Extensions
 
         TMP_Text target;
         internal CharInfo[] charInfoArray;
-        internal FastListCore<MotionHandle> motionHandleList = new(16);
+        internal FastListCore<MotionHandle> motionHandleList;
 
         TextMeshProMotionAnimator nextNode;
 

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionHandleLinker.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionHandleLinker.cs
@@ -8,9 +8,9 @@ namespace LitMotion
     [AddComponentMenu("")]
     internal sealed class MotionHandleLinker : MonoBehaviour
     {
-        FastListCore<MotionHandle> cancelOnDestroyList = new(8);
-        FastListCore<MotionHandle> cancelOnDisableList = new(8);
-        FastListCore<MotionHandle> completeOnDisableList = new(8);
+        FastListCore<MotionHandle> cancelOnDestroyList;
+        FastListCore<MotionHandle> cancelOnDisableList;
+        FastListCore<MotionHandle> completeOnDisableList;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Register(MotionHandle handle, LinkBehaviour linkBehaviour)

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionStorageManager.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionStorageManager.cs
@@ -6,7 +6,7 @@ namespace LitMotion
 {
     internal static class MotionStorageManager
     {
-        static FastListCore<IMotionStorage> storageList = new(16);
+        static FastListCore<IMotionStorage> storageList;
 
         public static int CurrentStorageId { get; private set; }
 

--- a/src/LitMotion/Assets/LitMotion/Runtime/ManualMotionDispatcher.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/ManualMotionDispatcher.cs
@@ -28,7 +28,7 @@ namespace LitMotion
             }
         }
 
-        static FastListCore<IUpdateRunner> updateRunners = new(16);
+        static FastListCore<IUpdateRunner> updateRunners;
 
         /// <summary>
         /// ManualMotionDispatcher time. It increases every time Update is called.

--- a/src/LitMotion/Assets/LitMotion/Runtime/MotionDispatcher.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/MotionDispatcher.cs
@@ -106,16 +106,16 @@ namespace LitMotion
             }
         }
 
-        static FastListCore<IUpdateRunner> initializationRunners = new(16);
-        static FastListCore<IUpdateRunner> earlyUpdateRunners = new(16);
-        static FastListCore<IUpdateRunner> fixedUpdateRunners = new(16);
-        static FastListCore<IUpdateRunner> preUpdateRunners = new(16);
-        static FastListCore<IUpdateRunner> updateRunners = new(16);
-        static FastListCore<IUpdateRunner> preLateUpdateRunners = new(16);
-        static FastListCore<IUpdateRunner> postLateUpdateRunners = new(16);
-        static FastListCore<IUpdateRunner> timeUpdateRunners = new(16);
+        static FastListCore<IUpdateRunner> initializationRunners;
+        static FastListCore<IUpdateRunner> earlyUpdateRunners;
+        static FastListCore<IUpdateRunner> fixedUpdateRunners;
+        static FastListCore<IUpdateRunner> preUpdateRunners;
+        static FastListCore<IUpdateRunner> updateRunners;
+        static FastListCore<IUpdateRunner> preLateUpdateRunners;
+        static FastListCore<IUpdateRunner> postLateUpdateRunners;
+        static FastListCore<IUpdateRunner> timeUpdateRunners;
 
-        internal static FastListCore<IUpdateRunner> EmptyList = new(0);
+        internal static FastListCore<IUpdateRunner> EmptyList = FastListCore<IUpdateRunner>.Empty;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static ref FastListCore<IUpdateRunner> GetRunnerList(PlayerLoopTiming playerLoopTiming)
@@ -273,7 +273,7 @@ namespace LitMotion
             }
         }
         
-        static FastListCore<IUpdateRunner> updateRunners = new(16);
+        static FastListCore<IUpdateRunner> updateRunners;
 
         public static MotionHandle Schedule<TValue, TOptions, TAdapter>(in MotionData<TValue, TOptions> data, in MotionCallbackData callbackData)
             where TValue : unmanaged


### PR DESCRIPTION
FastListCore runs the risk of forgetting to initialize, plus an empty list can cause an infinite loop in resize. To avoid this (and to avoid unnecessary allocations), the initialization process is delayed.