### PR TITLE
Add the functions that take Vector2 as input into LitMotionTransformExtensions.cs for 2D games.

### DIFF
--- a/src/LitMotion/Assets/LitMotion/Runtime/Extensions/General/LitMotionTransformExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Extensions/General/LitMotionTransformExtensions.cs
@@ -88,6 +88,50 @@ namespace LitMotion.Extensions
                 t.position = p;
             });
         }
+        
+        /// <summary>
+        /// Create a motion data and bind it to Transform.position.xy
+        /// </summary>
+        /// <typeparam name="TOptions">The type of special parameters given to the motion data</typeparam>
+        /// <typeparam name="TAdapter">The type of adapter that support value animation</typeparam>
+        /// <param name="builder">This builder</param>
+        /// <param name="transform"></param>
+        /// <returns>Handle of the created motion data.</returns>
+        public static MotionHandle BindToPositionXY<TOptions, TAdapter>(this MotionBuilder<Vector2, TOptions, TAdapter> builder, Transform transform)
+            where TOptions : unmanaged, IMotionOptions
+            where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
+        {
+            Error.IsNull(transform);
+            return builder.BindWithState(transform, static (x, t) =>
+            {
+                var p = t.position;
+                p.x = x.x;
+                p.y = x.y;
+                t.position = p;
+            });
+        }
+        
+        /// <summary>
+        /// Create a motion data and bind it to Transform.position.xz
+        /// </summary>
+        /// <typeparam name="TOptions">The type of special parameters given to the motion data</typeparam>
+        /// <typeparam name="TAdapter">The type of adapter that support value animation</typeparam>
+        /// <param name="builder">This builder</param>
+        /// <param name="transform"></param>
+        /// <returns>Handle of the created motion data.</returns>
+        public static MotionHandle BindToPositionXZ<TOptions, TAdapter>(this MotionBuilder<Vector2, TOptions, TAdapter> builder, Transform transform)
+            where TOptions : unmanaged, IMotionOptions
+            where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
+        {
+            Error.IsNull(transform);
+            return builder.BindWithState(transform, static (x, t) =>
+            {
+                var p = t.position;
+                p.x = x.x;
+                p.z = x.y;
+                t.position = p;
+            });
+        }
 
         /// <summary>
         /// Create a motion data and bind it to Transform.localPosition
@@ -168,6 +212,50 @@ namespace LitMotion.Extensions
             {
                 var p = t.localPosition;
                 p.z = x;
+                t.localPosition = p;
+            });
+        }
+        
+        /// <summary>
+        /// Create a motion data and bind it to Transform.localPosition.xy
+        /// </summary>
+        /// <typeparam name="TOptions">The type of special parameters given to the motion data</typeparam>
+        /// <typeparam name="TAdapter">The type of adapter that support value animation</typeparam>
+        /// <param name="builder">This builder</param>
+        /// <param name="transform"></param>
+        /// <returns>Handle of the created motion data.</returns>
+        public static MotionHandle BindToLocalPositionXY<TOptions, TAdapter>(this MotionBuilder<Vector2, TOptions, TAdapter> builder, Transform transform)
+            where TOptions : unmanaged, IMotionOptions
+            where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
+        {
+            Error.IsNull(transform);
+            return builder.BindWithState(transform, static (x, t) =>
+            {
+                var p = t.localPosition;
+                p.x = x.x;
+                p.y = x.y;
+                t.localPosition = p;
+            });
+        }
+        
+        /// <summary>
+        /// Create a motion data and bind it to Transform.localPosition.xz
+        /// </summary>
+        /// <typeparam name="TOptions">The type of special parameters given to the motion data</typeparam>
+        /// <typeparam name="TAdapter">The type of adapter that support value animation</typeparam>
+        /// <param name="builder">This builder</param>
+        /// <param name="transform"></param>
+        /// <returns>Handle of the created motion data.</returns>
+        public static MotionHandle BindToLocalPositionXZ<TOptions, TAdapter>(this MotionBuilder<Vector2, TOptions, TAdapter> builder, Transform transform)
+            where TOptions : unmanaged, IMotionOptions
+            where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
+        {
+            Error.IsNull(transform);
+            return builder.BindWithState(transform, static (x, t) =>
+            {
+                var p = t.localPosition;
+                p.x = x.x;
+                p.z = x.y;
                 t.localPosition = p;
             });
         }
@@ -452,6 +540,50 @@ namespace LitMotion.Extensions
             {
                 var p = t.localScale;
                 p.z = x;
+                t.localScale = p;
+            });
+        }
+        
+        /// <summary>
+        /// Create a motion data and bind it to Transform.localScale.xy
+        /// </summary>
+        /// <typeparam name="TOptions">The type of special parameters given to the motion data</typeparam>
+        /// <typeparam name="TAdapter">The type of adapter that support value animation</typeparam>
+        /// <param name="builder">This builder</param>
+        /// <param name="transform"></param>
+        /// <returns>Handle of the created motion data.</returns>
+        public static MotionHandle BindToLocalScaleXY<TOptions, TAdapter>(this MotionBuilder<Vector2, TOptions, TAdapter> builder, Transform transform)
+            where TOptions : unmanaged, IMotionOptions
+            where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
+        {
+            Error.IsNull(transform);
+            return builder.BindWithState(transform, static (x, t) =>
+            {
+                var p = t.localScale;
+                p.x = x.x;
+                p.y = x.y;
+                t.localScale = p;
+            });
+        }
+        
+        /// <summary>
+        /// Create a motion data and bind it to Transform.localScale.xz
+        /// </summary>
+        /// <typeparam name="TOptions">The type of special parameters given to the motion data</typeparam>
+        /// <typeparam name="TAdapter">The type of adapter that support value animation</typeparam>
+        /// <param name="builder">This builder</param>
+        /// <param name="transform"></param>
+        /// <returns>Handle of the created motion data.</returns>
+        public static MotionHandle BindToLocalScaleXZ<TOptions, TAdapter>(this MotionBuilder<Vector2, TOptions, TAdapter> builder, Transform transform)
+            where TOptions : unmanaged, IMotionOptions
+            where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
+        {
+            Error.IsNull(transform);
+            return builder.BindWithState(transform, static (x, t) =>
+            {
+                var p = t.localScale;
+                p.x = x.x;
+                p.z = x.y;
                 t.localScale = p;
             });
         }

--- a/src/LitMotion/Assets/LitMotion/Runtime/Extensions/General/LitMotionTransformExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Extensions/General/LitMotionTransformExtensions.cs
@@ -132,6 +132,28 @@ namespace LitMotion.Extensions
                 t.position = p;
             });
         }
+        
+        /// <summary>
+        /// Create a motion data and bind it to Transform.position.yz
+        /// </summary>
+        /// <typeparam name="TOptions">The type of special parameters given to the motion data</typeparam>
+        /// <typeparam name="TAdapter">The type of adapter that support value animation</typeparam>
+        /// <param name="builder">This builder</param>
+        /// <param name="transform"></param>
+        /// <returns>Handle of the created motion data.</returns>
+        public static MotionHandle BindToPositionYZ<TOptions, TAdapter>(this MotionBuilder<Vector2, TOptions, TAdapter> builder, Transform transform)
+            where TOptions : unmanaged, IMotionOptions
+            where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
+        {
+            Error.IsNull(transform);
+            return builder.BindWithState(transform, static (x, t) =>
+            {
+                var p = t.position;
+                p.y = x.x;
+                p.z = x.y;
+                t.position = p;
+            });
+        }
 
         /// <summary>
         /// Create a motion data and bind it to Transform.localPosition
@@ -259,6 +281,28 @@ namespace LitMotion.Extensions
                 t.localPosition = p;
             });
         }
+        
+        /// <summary>
+        /// Create a motion data and bind it to Transform.localPosition.yz
+        /// </summary>
+        /// <typeparam name="TOptions">The type of special parameters given to the motion data</typeparam>
+        /// <typeparam name="TAdapter">The type of adapter that support value animation</typeparam>
+        /// <param name="builder">This builder</param>
+        /// <param name="transform"></param>
+        /// <returns>Handle of the created motion data.</returns>
+        public static MotionHandle BindToLocalPositionYZ<TOptions, TAdapter>(this MotionBuilder<Vector2, TOptions, TAdapter> builder, Transform transform)
+            where TOptions : unmanaged, IMotionOptions
+            where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
+        {
+            Error.IsNull(transform);
+            return builder.BindWithState(transform, static (x, t) =>
+            {
+                var p = t.localPosition;
+                p.y = x.x;
+                p.z = x.y;
+                t.localPosition = p;
+            });
+        }
 
         /// <summary>
         /// Create a motion data and bind it to Transform.rotation
@@ -379,6 +423,72 @@ namespace LitMotion.Extensions
                 t.eulerAngles = p;
             });
         }
+        
+        /// <summary>
+        /// Create a motion data and bind it to Transform.eulerAngles.xy
+        /// </summary>
+        /// <typeparam name="TOptions">The type of special parameters given to the motion data</typeparam>
+        /// <typeparam name="TAdapter">The type of adapter that support value animation</typeparam>
+        /// <param name="builder">This builder</param>
+        /// <param name="transform"></param>
+        /// <returns>Handle of the created motion data.</returns>
+        public static MotionHandle BindToEulerAnglesXY<TOptions, TAdapter>(this MotionBuilder<Vector2, TOptions, TAdapter> builder, Transform transform)
+            where TOptions : unmanaged, IMotionOptions
+            where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
+        {
+            Error.IsNull(transform);
+            return builder.BindWithState(transform, static (x, t) =>
+            {
+                var p = t.eulerAngles;
+                p.x = x.x;
+                p.y = x.y;
+                t.eulerAngles = p;
+            });
+        }
+        
+        /// <summary>
+        /// Create a motion data and bind it to Transform.eulerAngles.xz
+        /// </summary>
+        /// <typeparam name="TOptions">The type of special parameters given to the motion data</typeparam>
+        /// <typeparam name="TAdapter">The type of adapter that support value animation</typeparam>
+        /// <param name="builder">This builder</param>
+        /// <param name="transform"></param>
+        /// <returns>Handle of the created motion data.</returns>
+        public static MotionHandle BindToEulerAnglesXZ<TOptions, TAdapter>(this MotionBuilder<Vector2, TOptions, TAdapter> builder, Transform transform)
+            where TOptions : unmanaged, IMotionOptions
+            where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
+        {
+            Error.IsNull(transform);
+            return builder.BindWithState(transform, static (x, t) =>
+            {
+                var p = t.eulerAngles;
+                p.x = x.x;
+                p.z = x.y;
+                t.eulerAngles = p;
+            });
+        }
+        
+        /// <summary>
+        /// Create a motion data and bind it to Transform.eulerAngles.yz
+        /// </summary>
+        /// <typeparam name="TOptions">The type of special parameters given to the motion data</typeparam>
+        /// <typeparam name="TAdapter">The type of adapter that support value animation</typeparam>
+        /// <param name="builder">This builder</param>
+        /// <param name="transform"></param>
+        /// <returns>Handle of the created motion data.</returns>
+        public static MotionHandle BindToEulerAnglesYZ<TOptions, TAdapter>(this MotionBuilder<Vector2, TOptions, TAdapter> builder, Transform transform)
+            where TOptions : unmanaged, IMotionOptions
+            where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
+        {
+            Error.IsNull(transform);
+            return builder.BindWithState(transform, static (x, t) =>
+            {
+                var p = t.eulerAngles;
+                p.y = x.x;
+                p.z = x.y;
+                t.eulerAngles = p;
+            });
+        }
 
         /// <summary>
         /// Create a motion data and bind it to Transform.localEulerAngles
@@ -458,6 +568,72 @@ namespace LitMotion.Extensions
             {
                 var p = t.localEulerAngles;
                 p.z = x;
+                t.localEulerAngles = p;
+            });
+        }
+        
+        /// <summary>
+        /// Create a motion data and bind it to Transform.localEulerAngles.xy
+        /// </summary>
+        /// <typeparam name="TOptions">The type of special parameters given to the motion data</typeparam>
+        /// <typeparam name="TAdapter">The type of adapter that support value animation</typeparam>
+        /// <param name="builder">This builder</param>
+        /// <param name="transform"></param>
+        /// <returns>Handle of the created motion data.</returns>
+        public static MotionHandle BindToLocalEulerAnglesXY<TOptions, TAdapter>(this MotionBuilder<Vector2, TOptions, TAdapter> builder, Transform transform)
+            where TOptions : unmanaged, IMotionOptions
+            where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
+        {
+            Error.IsNull(transform);
+            return builder.BindWithState(transform, static (x, t) =>
+            {
+                var p = t.localEulerAngles;
+                p.x = x.x;
+                p.y = x.y;
+                t.localEulerAngles = p;
+            });
+        }
+        
+        /// <summary>
+        /// Create a motion data and bind it to Transform.localEulerAngles.xz
+        /// </summary>
+        /// <typeparam name="TOptions">The type of special parameters given to the motion data</typeparam>
+        /// <typeparam name="TAdapter">The type of adapter that support value animation</typeparam>
+        /// <param name="builder">This builder</param>
+        /// <param name="transform"></param>
+        /// <returns>Handle of the created motion data.</returns>
+        public static MotionHandle BindToLocalEulerAnglesXZ<TOptions, TAdapter>(this MotionBuilder<Vector2, TOptions, TAdapter> builder, Transform transform)
+            where TOptions : unmanaged, IMotionOptions
+            where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
+        {
+            Error.IsNull(transform);
+            return builder.BindWithState(transform, static (x, t) =>
+            {
+                var p = t.localEulerAngles;
+                p.x = x.x;
+                p.z = x.y;
+                t.localEulerAngles = p;
+            });
+        }
+        
+        /// <summary>
+        /// Create a motion data and bind it to Transform.localEulerAngles.yz
+        /// </summary>
+        /// <typeparam name="TOptions">The type of special parameters given to the motion data</typeparam>
+        /// <typeparam name="TAdapter">The type of adapter that support value animation</typeparam>
+        /// <param name="builder">This builder</param>
+        /// <param name="transform"></param>
+        /// <returns>Handle of the created motion data.</returns>
+        public static MotionHandle BindToLocalEulerAnglesYZ<TOptions, TAdapter>(this MotionBuilder<Vector2, TOptions, TAdapter> builder, Transform transform)
+            where TOptions : unmanaged, IMotionOptions
+            where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
+        {
+            Error.IsNull(transform);
+            return builder.BindWithState(transform, static (x, t) =>
+            {
+                var p = t.localEulerAngles;
+                p.y = x.x;
+                p.z = x.y;
                 t.localEulerAngles = p;
             });
         }
@@ -583,6 +759,28 @@ namespace LitMotion.Extensions
             {
                 var p = t.localScale;
                 p.x = x.x;
+                p.z = x.y;
+                t.localScale = p;
+            });
+        }
+        
+        /// <summary>
+        /// Create a motion data and bind it to Transform.localScale.yz
+        /// </summary>
+        /// <typeparam name="TOptions">The type of special parameters given to the motion data</typeparam>
+        /// <typeparam name="TAdapter">The type of adapter that support value animation</typeparam>
+        /// <param name="builder">This builder</param>
+        /// <param name="transform"></param>
+        /// <returns>Handle of the created motion data.</returns>
+        public static MotionHandle BindToLocalScaleYZ<TOptions, TAdapter>(this MotionBuilder<Vector2, TOptions, TAdapter> builder, Transform transform)
+            where TOptions : unmanaged, IMotionOptions
+            where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
+        {
+            Error.IsNull(transform);
+            return builder.BindWithState(transform, static (x, t) =>
+            {
+                var p = t.localScale;
+                p.y = x.x;
                 p.z = x.y;
                 t.localScale = p;
             });

--- a/src/LitMotion/Assets/LitMotion/Tests/Runtime/TransformTest.cs
+++ b/src/LitMotion/Assets/LitMotion/Tests/Runtime/TransformTest.cs
@@ -55,6 +55,30 @@ namespace LitMotion.Tests.Runtime
             yield return LMotion.Create(1f, endValue, Duration).BindToPositionZ(target).ToYieldInteraction();
             Assert.That(target.position.z, Is.EqualTo(endValue).Using(FloatEqualityComparer.Instance));
         }
+        
+        [UnityTest]
+        public IEnumerator Test_BindToPositionXY()
+        {
+            var endValue = Vector2.one;
+            yield return LMotion.Create(Vector2.zero, endValue, Duration).BindToPositionXY(target).ToYieldInteraction();
+            Assert.That(new Vector2(target.position.x, target.position.y), Is.EqualTo(endValue).Using(Vector2EqualityComparer.Instance));
+        }
+        
+        [UnityTest]
+        public IEnumerator Test_BindToPositionXZ()
+        {
+            var endValue = Vector2.one;
+            yield return LMotion.Create(Vector2.zero, endValue, Duration).BindToPositionXZ(target).ToYieldInteraction();
+            Assert.That(new Vector2(target.position.x, target.position.z), Is.EqualTo(endValue).Using(Vector2EqualityComparer.Instance));
+        }
+        
+        [UnityTest]
+        public IEnumerator Test_BindToPositionYZ()
+        {
+            var endValue = Vector2.one;
+            yield return LMotion.Create(Vector2.zero, endValue, Duration).BindToPositionYZ(target).ToYieldInteraction();
+            Assert.That(new Vector2(target.position.y, target.position.z), Is.EqualTo(endValue).Using(Vector2EqualityComparer.Instance));
+        }
 
         [UnityTest]
         public IEnumerator Test_BindToLocalPosition()
@@ -86,6 +110,30 @@ namespace LitMotion.Tests.Runtime
             var endValue = 10f;
             yield return LMotion.Create(1f, endValue, Duration).BindToLocalPositionZ(target).ToYieldInteraction();
             Assert.That(target.localPosition.z, Is.EqualTo(endValue).Using(FloatEqualityComparer.Instance));
+        }
+        
+        [UnityTest]
+        public IEnumerator Test_BindToLocalPositionXY()
+        {
+            var endValue = Vector2.one;
+            yield return LMotion.Create(Vector2.zero, endValue, Duration).BindToLocalPositionXY(target).ToYieldInteraction();
+            Assert.That(new Vector2(target.localPosition.x, target.localPosition.y), Is.EqualTo(endValue).Using(Vector2EqualityComparer.Instance));
+        }
+        
+        [UnityTest]
+        public IEnumerator Test_BindToLocalPositionXZ()
+        {
+            var endValue = Vector2.one;
+            yield return LMotion.Create(Vector2.zero, endValue, Duration).BindToLocalPositionXZ(target).ToYieldInteraction();
+            Assert.That(new Vector2(target.localPosition.x, target.localPosition.z), Is.EqualTo(endValue).Using(Vector2EqualityComparer.Instance));
+        }
+        
+        [UnityTest]
+        public IEnumerator Test_BindToLocalPositionYZ()
+        {
+            var endValue = Vector2.one;
+            yield return LMotion.Create(Vector2.zero, endValue, Duration).BindToLocalPositionYZ(target).ToYieldInteraction();
+            Assert.That(new Vector2(target.localPosition.y, target.localPosition.z), Is.EqualTo(endValue).Using(Vector2EqualityComparer.Instance));
         }
 
         [UnityTest]
@@ -135,6 +183,30 @@ namespace LitMotion.Tests.Runtime
             yield return LMotion.Create(0f, endValue, Duration).BindToEulerAnglesZ(target).ToYieldInteraction();
             Assert.That(target.eulerAngles.z, Is.EqualTo(endValue).Using(FloatEqualityComparer.Instance));
         }
+        
+        [UnityTest]
+        public IEnumerator Test_BindToEulerAnglesXY()
+        {
+            var endValue = Vector2.one * 10f;
+            yield return LMotion.Create(Vector2.zero, endValue, Duration).BindToEulerAnglesXY(target).ToYieldInteraction();
+            Assert.That(new Vector2(target.eulerAngles.x, target.eulerAngles.y), Is.EqualTo(endValue).Using(Vector2EqualityComparer.Instance));
+        }
+        
+        [UnityTest]
+        public IEnumerator Test_BindToEulerAnglesXZ()
+        {
+            var endValue = Vector2.one * 10f;
+            yield return LMotion.Create(Vector2.zero, endValue, Duration).BindToEulerAnglesXZ(target).ToYieldInteraction();
+            Assert.That(new Vector2(target.eulerAngles.x, target.eulerAngles.z), Is.EqualTo(endValue).Using(Vector2EqualityComparer.Instance));
+        }
+        
+        [UnityTest]
+        public IEnumerator Test_BindToEulerAnglesYZ()
+        {
+            var endValue = Vector2.one * 10f;
+            yield return LMotion.Create(Vector2.zero, endValue, Duration).BindToEulerAnglesYZ(target).ToYieldInteraction();
+            Assert.That(new Vector2(target.eulerAngles.y, target.eulerAngles.z), Is.EqualTo(endValue).Using(Vector2EqualityComparer.Instance));
+        }
 
         [UnityTest]
         public IEnumerator Test_BindToLocalEulerAngles()
@@ -167,6 +239,30 @@ namespace LitMotion.Tests.Runtime
             yield return LMotion.Create(0f, endValue, Duration).BindToLocalEulerAnglesZ(target).ToYieldInteraction();
             Assert.That(target.localEulerAngles.z, Is.EqualTo(endValue).Using(FloatEqualityComparer.Instance));
         }
+        
+        [UnityTest]
+        public IEnumerator Test_BindToLocalEulerAnglesXY()
+        {
+            var endValue = Vector2.one * 10f;
+            yield return LMotion.Create(Vector2.zero, endValue, Duration).BindToLocalEulerAnglesXY(target).ToYieldInteraction();
+            Assert.That(new Vector2(target.localEulerAngles.x, target.localEulerAngles.y), Is.EqualTo(endValue).Using(Vector2EqualityComparer.Instance));
+        }
+        
+        [UnityTest]
+        public IEnumerator Test_BindToLocalEulerAnglesXZ()
+        {
+            var endValue = Vector2.one * 10f;
+            yield return LMotion.Create(Vector2.zero, endValue, Duration).BindToLocalEulerAnglesXZ(target).ToYieldInteraction();
+            Assert.That(new Vector2(target.localEulerAngles.x, target.localEulerAngles.z), Is.EqualTo(endValue).Using(Vector2EqualityComparer.Instance));
+        }
+        
+        [UnityTest]
+        public IEnumerator Test_BindToLocalEulerAnglesYZ()
+        {
+            var endValue = Vector2.one * 10f;
+            yield return LMotion.Create(Vector2.zero, endValue, Duration).BindToLocalEulerAnglesYZ(target).ToYieldInteraction();
+            Assert.That(new Vector2(target.localEulerAngles.y, target.localEulerAngles.z), Is.EqualTo(endValue).Using(Vector2EqualityComparer.Instance));
+        }
 
         [UnityTest]
         public IEnumerator Test_BindToLocalScale()
@@ -198,6 +294,30 @@ namespace LitMotion.Tests.Runtime
             var endValue = 2f;
             yield return LMotion.Create(1f, endValue, Duration).BindToLocalScaleZ(target).ToYieldInteraction();
             Assert.That(target.localScale.z, Is.EqualTo(endValue).Using(FloatEqualityComparer.Instance));
+        }
+        
+        [UnityTest]
+        public IEnumerator Test_BindToLocalScaleXY()
+        {
+            var endValue = Vector2.one * 2f;
+            yield return LMotion.Create(Vector2.one, endValue, Duration).BindToLocalScaleXY(target).ToYieldInteraction();
+            Assert.That(new Vector2(target.localScale.x, target.localScale.y), Is.EqualTo(endValue).Using(Vector2EqualityComparer.Instance));
+        }
+        
+        [UnityTest]
+        public IEnumerator Test_BindToLocalScaleXZ()
+        {
+            var endValue = Vector2.one * 2f;
+            yield return LMotion.Create(Vector2.one, endValue, Duration).BindToLocalScaleXZ(target).ToYieldInteraction();
+            Assert.That(new Vector2(target.localScale.x, target.localScale.z), Is.EqualTo(endValue).Using(Vector2EqualityComparer.Instance));
+        }
+        
+        [UnityTest]
+        public IEnumerator Test_BindToLocalScaleYZ()
+        {
+            var endValue = Vector2.one * 2f;
+            yield return LMotion.Create(Vector2.one, endValue, Duration).BindToLocalScaleYZ(target).ToYieldInteraction();
+            Assert.That(new Vector2(target.localScale.y, target.localScale.z), Is.EqualTo(endValue).Using(Vector2EqualityComparer.Instance));
         }
     }
 }


### PR DESCRIPTION
Add `BindToPositionXY`, `BindToPositionXZ`, `BindToLocalPositionXY`, `BindToLocalPositionXZ`, `BindToLocalScaleXY`, `BindToLocalScaleXZ` to LitMotionTransformExtensions.cs.

It is quite common to use Vector2 for position and scale when making 2d games, and there are no relevant function available for that purpose. The Vector3 functions are not suitable since we do not want to change the z-component value when using these functions. The casting cost is also a concern.