### PR TITLE
Add: WithBindOnSchedule

### DIFF
--- a/src/LitMotion/Assets/LitMotion/Tests/Runtime/BindOnScheduleTest.cs
+++ b/src/LitMotion/Assets/LitMotion/Tests/Runtime/BindOnScheduleTest.cs
@@ -1,0 +1,47 @@
+using NUnit.Framework;
+using UnityEngine;
+
+namespace LitMotion.Tests.Runtime
+{
+    public class BindOnScheduleTest
+    {
+        [Test]
+        public void Test_BindOnSchedule()
+        {
+            var value = 0f;
+
+            var motion = LMotion.Create(1f, 0f, 1f)
+                .Bind(x => value = x);
+
+            motion.Cancel();
+
+            Assert.That(value, Is.EqualTo(0f));
+
+            value = 0f;
+
+            motion = LMotion.Create(1f, 0f, 1f)
+                .WithBindOnSchedule()
+                .Bind(x => value = x);
+
+            motion.Cancel();
+
+            Assert.That(value, Is.EqualTo(1f));
+        }
+
+        [Test]
+        public void Test_BindOnSchedule_AnimationCurve()
+        {
+            var curve = AnimationCurve.EaseInOut(0f, 1f, 1f, 0f);
+
+            var value = 0f;
+            var motion = LMotion.Create(0f, 1f, 1f)
+                .WithEase(curve)
+                .WithBindOnSchedule()
+                .Bind(x => value = x);
+
+            motion.Cancel();
+
+            Assert.That(value, Is.EqualTo(1f));
+        }
+    }
+}

--- a/src/LitMotion/Assets/LitMotion/Tests/Runtime/BindOnScheduleTest.cs.meta
+++ b/src/LitMotion/Assets/LitMotion/Tests/Runtime/BindOnScheduleTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c0b80c588b36d4181be814f112e42bc0


### PR DESCRIPTION
Add the `WithBindOnSchedule` option. Enabling this will calculate the initial value to bind when scheduling a motion.