### PR TITLE
Change: `BindWithState` -> `Bind`

### DIFF
--- a/src/LitMotion/Assets/LitMotion/Runtime/Extensions/General/LitMotionAudioExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Extensions/General/LitMotionAudioExtensions.cs
@@ -22,7 +22,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(audioSource);
-            return builder.BindWithState(audioSource, static (x, target) =>
+            return builder.Bind(audioSource, static (x, target) =>
             {
                 target.volume = x;
             });
@@ -41,7 +41,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(audioSource);
-            return builder.BindWithState(audioSource, static (x, target) =>
+            return builder.Bind(audioSource, static (x, target) =>
             {
                 target.pitch = x;
             });
@@ -60,7 +60,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(audioMixer);
-            return builder.BindWithState((audioMixer, name), static (x, state) =>
+            return builder.Bind((audioMixer, name), static (x, state) =>
             {
                 state.audioMixer.SetFloat(state.name, x);
             });

--- a/src/LitMotion/Assets/LitMotion/Runtime/Extensions/General/LitMotionAudioExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Extensions/General/LitMotionAudioExtensions.cs
@@ -60,9 +60,9 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(audioMixer);
-            return builder.BindWithState(audioMixer, name, static (x, target, n) =>
+            return builder.BindWithState((audioMixer, name), static (x, state) =>
             {
-                target.SetFloat(n, x);
+                state.audioMixer.SetFloat(state.name, x);
             });
         }
     }

--- a/src/LitMotion/Assets/LitMotion/Runtime/Extensions/General/LitMotionMaterialExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Extensions/General/LitMotionMaterialExtensions.cs
@@ -20,7 +20,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(material);
-            return builder.BindWithState((material, name), static (x, state) =>
+            return builder.Bind((material, name), static (x, state) =>
             {
                 state.material.SetFloat(state.name, x);
             });
@@ -39,7 +39,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(material);
-            return builder.BindWithState(material, (x, m) =>
+            return builder.Bind(material, (x, m) =>
             {
                 m.SetFloat(nameID, x);
             });
@@ -58,7 +58,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<int, TOptions>
         {
             Error.IsNull(material);
-            return builder.BindWithState((material, name), static (x, state) =>
+            return builder.Bind((material, name), static (x, state) =>
             {
                 state.material.SetInteger(state.name, x);
             });
@@ -77,7 +77,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<int, TOptions>
         {
             Error.IsNull(material);
-            return builder.BindWithState(material, (x, m) =>
+            return builder.Bind(material, (x, m) =>
             {
                 m.SetInteger(nameID, x);
             });
@@ -96,7 +96,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Color, TOptions>
         {
             Error.IsNull(material);
-            return builder.BindWithState((material, name), static (x, state) =>
+            return builder.Bind((material, name), static (x, state) =>
             {
                 state.material.SetColor(state.name, x);
             });
@@ -115,7 +115,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Color, TOptions>
         {
             Error.IsNull(material);
-            return builder.BindWithState(material, (x, m) =>
+            return builder.Bind(material, (x, m) =>
             {
                 m.SetColor(nameID, x);
             });

--- a/src/LitMotion/Assets/LitMotion/Runtime/Extensions/General/LitMotionMaterialExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Extensions/General/LitMotionMaterialExtensions.cs
@@ -20,9 +20,9 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(material);
-            return builder.BindWithState(material, name, static (x, m, n) =>
+            return builder.BindWithState((material, name), static (x, state) =>
             {
-                m.SetFloat(n, x);
+                state.material.SetFloat(state.name, x);
             });
         }
 
@@ -58,9 +58,9 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<int, TOptions>
         {
             Error.IsNull(material);
-            return builder.BindWithState(material, name, static (x, m, n) =>
+            return builder.BindWithState((material, name), static (x, state) =>
             {
-                m.SetInteger(n, x);
+                state.material.SetInteger(state.name, x);
             });
         }
 
@@ -96,9 +96,9 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Color, TOptions>
         {
             Error.IsNull(material);
-            return builder.BindWithState(material, name, static (x, m, n) =>
+            return builder.BindWithState((material, name), static (x, state) =>
             {
-                m.SetColor(n, x);
+                state.material.SetColor(state.name, x);
             });
         }
 

--- a/src/LitMotion/Assets/LitMotion/Runtime/Extensions/General/LitMotionSpriteRendererExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Extensions/General/LitMotionSpriteRendererExtensions.cs
@@ -20,7 +20,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Color, TOptions>
         {
             Error.IsNull(spriteRenderer);
-            return builder.BindWithState(spriteRenderer, static (x, m) =>
+            return builder.Bind(spriteRenderer, static (x, m) =>
             {
                 m.color = x;
             });
@@ -39,7 +39,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(spriteRenderer);
-            return builder.BindWithState(spriteRenderer, static (x, m) =>
+            return builder.Bind(spriteRenderer, static (x, m) =>
             {
                 var c = m.color;
                 c.r = x;
@@ -60,7 +60,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(spriteRenderer);
-            return builder.BindWithState(spriteRenderer, static (x, m) =>
+            return builder.Bind(spriteRenderer, static (x, m) =>
             {
                 var c = m.color;
                 c.g = x;
@@ -81,7 +81,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(spriteRenderer);
-            return builder.BindWithState(spriteRenderer, static (x, m) =>
+            return builder.Bind(spriteRenderer, static (x, m) =>
             {
                 var c = m.color;
                 c.b = x;
@@ -102,7 +102,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(spriteRenderer);
-            return builder.BindWithState(spriteRenderer, static (x, m) =>
+            return builder.Bind(spriteRenderer, static (x, m) =>
             {
                 var c = m.color;
                 c.a = x;

--- a/src/LitMotion/Assets/LitMotion/Runtime/Extensions/General/LitMotionTransformExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Extensions/General/LitMotionTransformExtensions.cs
@@ -20,7 +20,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector3, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, static (x, t) =>
+            return builder.Bind(transform, static (x, t) =>
             {
                 t.position = x;
             });
@@ -39,7 +39,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, static (x, t) =>
+            return builder.Bind(transform, static (x, t) =>
             {
                 var p = t.position;
                 p.x = x;
@@ -60,7 +60,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, static (x, t) =>
+            return builder.Bind(transform, static (x, t) =>
             {
                 var p = t.position;
                 p.y = x;
@@ -81,14 +81,14 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, static (x, t) =>
+            return builder.Bind(transform, static (x, t) =>
             {
                 var p = t.position;
                 p.z = x;
                 t.position = p;
             });
         }
-        
+
         /// <summary>
         /// Create a motion data and bind it to Transform.position.xy
         /// </summary>
@@ -102,7 +102,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, static (x, t) =>
+            return builder.Bind(transform, static (x, t) =>
             {
                 var p = t.position;
                 p.x = x.x;
@@ -110,7 +110,7 @@ namespace LitMotion.Extensions
                 t.position = p;
             });
         }
-        
+
         /// <summary>
         /// Create a motion data and bind it to Transform.position.xz
         /// </summary>
@@ -124,7 +124,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, static (x, t) =>
+            return builder.Bind(transform, static (x, t) =>
             {
                 var p = t.position;
                 p.x = x.x;
@@ -132,7 +132,7 @@ namespace LitMotion.Extensions
                 t.position = p;
             });
         }
-        
+
         /// <summary>
         /// Create a motion data and bind it to Transform.position.yz
         /// </summary>
@@ -146,7 +146,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, static (x, t) =>
+            return builder.Bind(transform, static (x, t) =>
             {
                 var p = t.position;
                 p.y = x.x;
@@ -168,7 +168,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector3, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, static (x, t) =>
+            return builder.Bind(transform, static (x, t) =>
             {
                 t.localPosition = x;
             });
@@ -187,7 +187,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, static (x, t) =>
+            return builder.Bind(transform, static (x, t) =>
             {
                 var p = t.localPosition;
                 p.x = x;
@@ -209,7 +209,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, static (x, t) =>
+            return builder.Bind(transform, static (x, t) =>
             {
                 var p = t.localPosition;
                 p.y = x;
@@ -230,14 +230,14 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, static (x, t) =>
+            return builder.Bind(transform, static (x, t) =>
             {
                 var p = t.localPosition;
                 p.z = x;
                 t.localPosition = p;
             });
         }
-        
+
         /// <summary>
         /// Create a motion data and bind it to Transform.localPosition.xy
         /// </summary>
@@ -251,7 +251,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, static (x, t) =>
+            return builder.Bind(transform, static (x, t) =>
             {
                 var p = t.localPosition;
                 p.x = x.x;
@@ -259,7 +259,7 @@ namespace LitMotion.Extensions
                 t.localPosition = p;
             });
         }
-        
+
         /// <summary>
         /// Create a motion data and bind it to Transform.localPosition.xz
         /// </summary>
@@ -273,7 +273,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, static (x, t) =>
+            return builder.Bind(transform, static (x, t) =>
             {
                 var p = t.localPosition;
                 p.x = x.x;
@@ -281,7 +281,7 @@ namespace LitMotion.Extensions
                 t.localPosition = p;
             });
         }
-        
+
         /// <summary>
         /// Create a motion data and bind it to Transform.localPosition.yz
         /// </summary>
@@ -295,7 +295,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, static (x, t) =>
+            return builder.Bind(transform, static (x, t) =>
             {
                 var p = t.localPosition;
                 p.y = x.x;
@@ -317,7 +317,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Quaternion, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, static (x, t) =>
+            return builder.Bind(transform, static (x, t) =>
             {
                 t.rotation = x;
             });
@@ -336,7 +336,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Quaternion, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, static (x, t) =>
+            return builder.Bind(transform, static (x, t) =>
             {
                 t.localRotation = x;
             });
@@ -355,7 +355,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector3, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, static (x, t) =>
+            return builder.Bind(transform, static (x, t) =>
             {
                 t.eulerAngles = x;
             });
@@ -374,7 +374,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, static (x, t) =>
+            return builder.Bind(transform, static (x, t) =>
             {
                 var p = t.eulerAngles;
                 p.x = x;
@@ -395,7 +395,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, static (x, t) =>
+            return builder.Bind(transform, static (x, t) =>
             {
                 var p = t.eulerAngles;
                 p.y = x;
@@ -416,14 +416,14 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, static (x, t) =>
+            return builder.Bind(transform, static (x, t) =>
             {
                 var p = t.eulerAngles;
                 p.z = x;
                 t.eulerAngles = p;
             });
         }
-        
+
         /// <summary>
         /// Create a motion data and bind it to Transform.eulerAngles.xy
         /// </summary>
@@ -437,7 +437,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, static (x, t) =>
+            return builder.Bind(transform, static (x, t) =>
             {
                 var p = t.eulerAngles;
                 p.x = x.x;
@@ -445,7 +445,7 @@ namespace LitMotion.Extensions
                 t.eulerAngles = p;
             });
         }
-        
+
         /// <summary>
         /// Create a motion data and bind it to Transform.eulerAngles.xz
         /// </summary>
@@ -459,7 +459,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, static (x, t) =>
+            return builder.Bind(transform, static (x, t) =>
             {
                 var p = t.eulerAngles;
                 p.x = x.x;
@@ -467,7 +467,7 @@ namespace LitMotion.Extensions
                 t.eulerAngles = p;
             });
         }
-        
+
         /// <summary>
         /// Create a motion data and bind it to Transform.eulerAngles.yz
         /// </summary>
@@ -481,7 +481,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, static (x, t) =>
+            return builder.Bind(transform, static (x, t) =>
             {
                 var p = t.eulerAngles;
                 p.y = x.x;
@@ -503,7 +503,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector3, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, static (x, t) =>
+            return builder.Bind(transform, static (x, t) =>
             {
                 t.localEulerAngles = x;
             });
@@ -522,7 +522,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, static (x, t) =>
+            return builder.Bind(transform, static (x, t) =>
             {
                 var p = t.localEulerAngles;
                 p.x = x;
@@ -543,7 +543,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, static (x, t) =>
+            return builder.Bind(transform, static (x, t) =>
             {
                 var p = t.localEulerAngles;
                 p.y = x;
@@ -564,14 +564,14 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, static (x, t) =>
+            return builder.Bind(transform, static (x, t) =>
             {
                 var p = t.localEulerAngles;
                 p.z = x;
                 t.localEulerAngles = p;
             });
         }
-        
+
         /// <summary>
         /// Create a motion data and bind it to Transform.localEulerAngles.xy
         /// </summary>
@@ -585,7 +585,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, static (x, t) =>
+            return builder.Bind(transform, static (x, t) =>
             {
                 var p = t.localEulerAngles;
                 p.x = x.x;
@@ -593,7 +593,7 @@ namespace LitMotion.Extensions
                 t.localEulerAngles = p;
             });
         }
-        
+
         /// <summary>
         /// Create a motion data and bind it to Transform.localEulerAngles.xz
         /// </summary>
@@ -607,7 +607,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, static (x, t) =>
+            return builder.Bind(transform, static (x, t) =>
             {
                 var p = t.localEulerAngles;
                 p.x = x.x;
@@ -615,7 +615,7 @@ namespace LitMotion.Extensions
                 t.localEulerAngles = p;
             });
         }
-        
+
         /// <summary>
         /// Create a motion data and bind it to Transform.localEulerAngles.yz
         /// </summary>
@@ -629,7 +629,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, static (x, t) =>
+            return builder.Bind(transform, static (x, t) =>
             {
                 var p = t.localEulerAngles;
                 p.y = x.x;
@@ -651,7 +651,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector3, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, static (x, t) =>
+            return builder.Bind(transform, static (x, t) =>
             {
                 t.localScale = x;
             });
@@ -670,7 +670,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, static (x, t) =>
+            return builder.Bind(transform, static (x, t) =>
             {
                 var p = t.localScale;
                 p.x = x;
@@ -691,7 +691,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, static (x, t) =>
+            return builder.Bind(transform, static (x, t) =>
             {
                 var p = t.localScale;
                 p.y = x;
@@ -712,14 +712,14 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, static (x, t) =>
+            return builder.Bind(transform, static (x, t) =>
             {
                 var p = t.localScale;
                 p.z = x;
                 t.localScale = p;
             });
         }
-        
+
         /// <summary>
         /// Create a motion data and bind it to Transform.localScale.xy
         /// </summary>
@@ -733,7 +733,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, static (x, t) =>
+            return builder.Bind(transform, static (x, t) =>
             {
                 var p = t.localScale;
                 p.x = x.x;
@@ -741,7 +741,7 @@ namespace LitMotion.Extensions
                 t.localScale = p;
             });
         }
-        
+
         /// <summary>
         /// Create a motion data and bind it to Transform.localScale.xz
         /// </summary>
@@ -755,7 +755,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, static (x, t) =>
+            return builder.Bind(transform, static (x, t) =>
             {
                 var p = t.localScale;
                 p.x = x.x;
@@ -763,7 +763,7 @@ namespace LitMotion.Extensions
                 t.localScale = p;
             });
         }
-        
+
         /// <summary>
         /// Create a motion data and bind it to Transform.localScale.yz
         /// </summary>
@@ -777,7 +777,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
         {
             Error.IsNull(transform);
-            return builder.BindWithState(transform, static (x, t) =>
+            return builder.Bind(transform, static (x, t) =>
             {
                 var p = t.localScale;
                 p.y = x.x;

--- a/src/LitMotion/Assets/LitMotion/Runtime/Extensions/TextMeshPro/LitMotionTextMeshProExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Extensions/TextMeshPro/LitMotionTextMeshProExtensions.cs
@@ -383,12 +383,12 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<int, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, format, static (x, target, format) =>
+            return builder.BindWithState((text, format), static (x, state) =>
             {
 #if LITMOTION_SUPPORT_ZSTRING
-                target.SetTextFormat(format, x);
+                state.text.SetTextFormat(state.format, x);
 #else
-                target.text = string.Format(format, x);
+                state.text.text = string.Format(state.format, x);
 #endif
             });
         }
@@ -433,12 +433,12 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<long, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, format, static (x, target, format) =>
+            return builder.BindWithState((text, format), static (x, state) =>
             {
 #if LITMOTION_SUPPORT_ZSTRING
-                target.SetTextFormat(format, x);
+                state.text.SetTextFormat(state.format, x);
 #else
-                target.text = string.Format(format, x);
+                state.text.text = string.Format(state.format, x);
 #endif
             });
         }
@@ -483,12 +483,12 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, format, static (x, target, format) =>
+            return builder.BindWithState((text, format), static (x, state) =>
             {
 #if LITMOTION_SUPPORT_ZSTRING
-                target.SetTextFormat(format, x);
+                state.text.SetTextFormat(state.format, x);
 #else
-                target.text = string.Format(format, x);
+                state.text.text = string.Format(state.format, x);
 #endif
             });
         }

--- a/src/LitMotion/Assets/LitMotion/Runtime/Extensions/TextMeshPro/LitMotionTextMeshProExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Extensions/TextMeshPro/LitMotionTextMeshProExtensions.cs
@@ -27,7 +27,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, static (x, target) =>
+            return builder.Bind(text, static (x, target) =>
             {
                 target.fontSize = x;
             });
@@ -46,7 +46,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<int, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, static (x, target) =>
+            return builder.Bind(text, static (x, target) =>
             {
                 target.maxVisibleCharacters = x;
             });
@@ -65,7 +65,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<int, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, static (x, target) =>
+            return builder.Bind(text, static (x, target) =>
             {
                 target.maxVisibleLines = x;
             });
@@ -84,7 +84,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<int, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, static (x, target) =>
+            return builder.Bind(text, static (x, target) =>
             {
                 target.maxVisibleWords = x;
             });
@@ -103,7 +103,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Color, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, static (x, target) =>
+            return builder.Bind(text, static (x, target) =>
             {
                 target.color = x;
             });
@@ -122,7 +122,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, static (x, target) =>
+            return builder.Bind(text, static (x, target) =>
             {
                 var c = target.color;
                 c.r = x;
@@ -143,7 +143,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, static (x, target) =>
+            return builder.Bind(text, static (x, target) =>
             {
                 var c = target.color;
                 c.g = x;
@@ -164,7 +164,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, static (x, target) =>
+            return builder.Bind(text, static (x, target) =>
             {
                 var c = target.color;
                 c.b = x;
@@ -185,7 +185,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, static (x, target) =>
+            return builder.Bind(text, static (x, target) =>
             {
                 var c = target.color;
                 c.a = x;
@@ -209,7 +209,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<FixedString32Bytes, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, static (x, target) =>
+            return builder.Bind(text, static (x, target) =>
             {
                 var enumerator = x.GetEnumerator();
                 var length = 0;
@@ -239,7 +239,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<FixedString64Bytes, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, static (x, target) =>
+            return builder.Bind(text, static (x, target) =>
             {
                 var enumerator = x.GetEnumerator();
                 var length = 0;
@@ -269,7 +269,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<FixedString128Bytes, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, static (x, target) =>
+            return builder.Bind(text, static (x, target) =>
             {
                 var enumerator = x.GetEnumerator();
                 var length = 0;
@@ -299,7 +299,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<FixedString512Bytes, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, static (x, target) =>
+            return builder.Bind(text, static (x, target) =>
             {
                 var enumerator = x.GetEnumerator();
                 var length = 0;
@@ -329,7 +329,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<FixedString4096Bytes, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, static (x, target) =>
+            return builder.Bind(text, static (x, target) =>
             {
                 var enumerator = x.GetEnumerator();
                 var length = 0;
@@ -358,7 +358,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<int, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, static (x, target) =>
+            return builder.Bind(text, static (x, target) =>
             {
 
                 var buffer = ArrayPool<char>.Shared.Rent(128);
@@ -383,7 +383,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<int, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState((text, format), static (x, state) =>
+            return builder.Bind((text, format), static (x, state) =>
             {
 #if LITMOTION_SUPPORT_ZSTRING
                 state.text.SetTextFormat(state.format, x);
@@ -408,7 +408,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<long, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, static (x, target) =>
+            return builder.Bind(text, static (x, target) =>
             {
 
                 var buffer = ArrayPool<char>.Shared.Rent(128);
@@ -433,7 +433,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<long, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState((text, format), static (x, state) =>
+            return builder.Bind((text, format), static (x, state) =>
             {
 #if LITMOTION_SUPPORT_ZSTRING
                 state.text.SetTextFormat(state.format, x);
@@ -459,7 +459,7 @@ namespace LitMotion.Extensions
         {
             const string format = "{0}";
             Error.IsNull(text);
-            return builder.BindWithState(text, static (x, target) =>
+            return builder.Bind(text, static (x, target) =>
             {
 #if LITMOTION_SUPPORT_ZSTRING
                 target.SetTextFormat(format, x);
@@ -483,7 +483,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState((text, format), static (x, state) =>
+            return builder.Bind((text, format), static (x, state) =>
             {
 #if LITMOTION_SUPPORT_ZSTRING
                 state.text.SetTextFormat(state.format, x);
@@ -510,7 +510,7 @@ namespace LitMotion.Extensions
 
             var animator = TextMeshProMotionAnimator.Get(text);
             animator.EnsureCapacity(charIndex + 1);
-            var handle = builder.BindWithState(animator, (x, target) =>
+            var handle = builder.Bind(animator, (x, target) =>
             {
                 animator.charInfoArray[charIndex].color = x;
             });
@@ -536,7 +536,7 @@ namespace LitMotion.Extensions
 
             var animator = TextMeshProMotionAnimator.Get(text);
             animator.EnsureCapacity(charIndex + 1);
-            var handle = builder.BindWithState(animator, (x, target) =>
+            var handle = builder.Bind(animator, (x, target) =>
             {
                 animator.charInfoArray[charIndex].color.r = x;
             });
@@ -562,7 +562,7 @@ namespace LitMotion.Extensions
 
             var animator = TextMeshProMotionAnimator.Get(text);
             animator.EnsureCapacity(charIndex + 1);
-            var handle = builder.BindWithState(animator, (x, target) =>
+            var handle = builder.Bind(animator, (x, target) =>
             {
                 animator.charInfoArray[charIndex].color.g = x;
             });
@@ -588,7 +588,7 @@ namespace LitMotion.Extensions
 
             var animator = TextMeshProMotionAnimator.Get(text);
             animator.EnsureCapacity(charIndex + 1);
-            var handle = builder.BindWithState(animator, (x, target) =>
+            var handle = builder.Bind(animator, (x, target) =>
             {
                 animator.charInfoArray[charIndex].color.b = x;
             });
@@ -614,7 +614,7 @@ namespace LitMotion.Extensions
 
             var animator = TextMeshProMotionAnimator.Get(text);
             animator.EnsureCapacity(charIndex + 1);
-            var handle = builder.BindWithState(animator, (x, target) =>
+            var handle = builder.Bind(animator, (x, target) =>
             {
                 animator.charInfoArray[charIndex].color.a = x;
             });
@@ -640,7 +640,7 @@ namespace LitMotion.Extensions
 
             var animator = TextMeshProMotionAnimator.Get(text);
             animator.EnsureCapacity(charIndex + 1);
-            var handle = builder.BindWithState(animator, (x, target) =>
+            var handle = builder.Bind(animator, (x, target) =>
             {
                 animator.charInfoArray[charIndex].position = x;
             });
@@ -666,7 +666,7 @@ namespace LitMotion.Extensions
 
             var animator = TextMeshProMotionAnimator.Get(text);
             animator.EnsureCapacity(charIndex + 1);
-            var handle = builder.BindWithState(animator, (x, target) =>
+            var handle = builder.Bind(animator, (x, target) =>
             {
                 animator.charInfoArray[charIndex].position.x = x;
             });
@@ -692,7 +692,7 @@ namespace LitMotion.Extensions
 
             var animator = TextMeshProMotionAnimator.Get(text);
             animator.EnsureCapacity(charIndex + 1);
-            var handle = builder.BindWithState(animator, (x, target) =>
+            var handle = builder.Bind(animator, (x, target) =>
             {
                 animator.charInfoArray[charIndex].position.y = x;
             });
@@ -718,7 +718,7 @@ namespace LitMotion.Extensions
 
             var animator = TextMeshProMotionAnimator.Get(text);
             animator.EnsureCapacity(charIndex + 1);
-            var handle = builder.BindWithState(animator, (x, target) =>
+            var handle = builder.Bind(animator, (x, target) =>
             {
                 animator.charInfoArray[charIndex].position.z = x;
             });
@@ -744,7 +744,7 @@ namespace LitMotion.Extensions
 
             var animator = TextMeshProMotionAnimator.Get(text);
             animator.EnsureCapacity(charIndex + 1);
-            var handle = builder.BindWithState(animator, (x, target) =>
+            var handle = builder.Bind(animator, (x, target) =>
             {
                 animator.charInfoArray[charIndex].rotation = x;
             });
@@ -770,7 +770,7 @@ namespace LitMotion.Extensions
 
             var animator = TextMeshProMotionAnimator.Get(text);
             animator.EnsureCapacity(charIndex + 1);
-            var handle = builder.BindWithState(animator, (x, target) =>
+            var handle = builder.Bind(animator, (x, target) =>
             {
                 animator.charInfoArray[charIndex].rotation = Quaternion.Euler(x);
             });
@@ -796,7 +796,7 @@ namespace LitMotion.Extensions
 
             var animator = TextMeshProMotionAnimator.Get(text);
             animator.EnsureCapacity(charIndex + 1);
-            var handle = builder.BindWithState(animator, (x, target) =>
+            var handle = builder.Bind(animator, (x, target) =>
             {
                 var eulerAngles = animator.charInfoArray[charIndex].rotation.eulerAngles;
                 eulerAngles.x = x;
@@ -824,7 +824,7 @@ namespace LitMotion.Extensions
 
             var animator = TextMeshProMotionAnimator.Get(text);
             animator.EnsureCapacity(charIndex + 1);
-            var handle = builder.BindWithState(animator, (x, target) =>
+            var handle = builder.Bind(animator, (x, target) =>
             {
                 var eulerAngles = animator.charInfoArray[charIndex].rotation.eulerAngles;
                 eulerAngles.y = x;
@@ -852,7 +852,7 @@ namespace LitMotion.Extensions
 
             var animator = TextMeshProMotionAnimator.Get(text);
             animator.EnsureCapacity(charIndex + 1);
-            var handle = builder.BindWithState(animator, (x, target) =>
+            var handle = builder.Bind(animator, (x, target) =>
             {
                 var eulerAngles = animator.charInfoArray[charIndex].rotation.eulerAngles;
                 eulerAngles.z = x;
@@ -880,7 +880,7 @@ namespace LitMotion.Extensions
 
             var animator = TextMeshProMotionAnimator.Get(text);
             animator.EnsureCapacity(charIndex + 1);
-            var handle = builder.BindWithState(animator, (x, target) =>
+            var handle = builder.Bind(animator, (x, target) =>
             {
                 animator.charInfoArray[charIndex].scale = x;
             });
@@ -906,7 +906,7 @@ namespace LitMotion.Extensions
 
             var animator = TextMeshProMotionAnimator.Get(text);
             animator.EnsureCapacity(charIndex + 1);
-            var handle = builder.BindWithState(animator, (x, target) =>
+            var handle = builder.Bind(animator, (x, target) =>
             {
                 animator.charInfoArray[charIndex].scale.x = x;
             });
@@ -932,7 +932,7 @@ namespace LitMotion.Extensions
 
             var animator = TextMeshProMotionAnimator.Get(text);
             animator.EnsureCapacity(charIndex + 1);
-            var handle = builder.BindWithState(animator, (x, target) =>
+            var handle = builder.Bind(animator, (x, target) =>
             {
                 animator.charInfoArray[charIndex].scale.y = x;
             });
@@ -958,7 +958,7 @@ namespace LitMotion.Extensions
 
             var animator = TextMeshProMotionAnimator.Get(text);
             animator.EnsureCapacity(charIndex + 1);
-            var handle = builder.BindWithState(animator, (x, target) =>
+            var handle = builder.Bind(animator, (x, target) =>
             {
                 animator.charInfoArray[charIndex].scale.z = x;
             });

--- a/src/LitMotion/Assets/LitMotion/Runtime/Extensions/UIToolkit/LitMotionUIToolkitExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Extensions/UIToolkit/LitMotionUIToolkitExtensions.cs
@@ -661,12 +661,12 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<int, TOptions>
         {
             Error.IsNull(textElement);
-            return builder.BindWithState(textElement, format, static (x, target, f) =>
+            return builder.BindWithState((textElement, format), static (x, state) =>
             {
 #if LITMOTION_SUPPORT_ZSTRING
-                target.text = ZString.Format(f, x);
+                state.textElement.text = ZString.Format(state.format, x);
 #else
-                target.text = string.Format(f, x);
+                state.textElement.text = string.Format(state.format, x);
 #endif
             });
         }
@@ -704,12 +704,12 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<long, TOptions>
         {
             Error.IsNull(textElement);
-            return builder.BindWithState(textElement, format, static (x, target, format) =>
+            return builder.BindWithState((textElement, format), static (x, state) =>
             {
 #if LITMOTION_SUPPORT_ZSTRING
-                target.text = ZString.Format(format, x);
+                state.textElement.text = ZString.Format(state.format, x);
 #else
-                target.text = string.Format(format, x);
+                state.textElement.text = string.Format(state.format, x);
 #endif
             });
         }
@@ -747,12 +747,12 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(textElement);
-            return builder.BindWithState(textElement, format, static (x, target, format) =>
+            return builder.BindWithState((textElement, format), static (x, state) =>
             {
 #if LITMOTION_SUPPORT_ZSTRING
-                target.text = ZString.Format(format, x);
+                state.textElement.text = ZString.Format(state.format, x);
 #else
-                target.text = string.Format(format, x);
+                state.textElement.text = string.Format(state.format, x);
 #endif
             });
         }

--- a/src/LitMotion/Assets/LitMotion/Runtime/Extensions/UIToolkit/LitMotionUIToolkitExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Extensions/UIToolkit/LitMotionUIToolkitExtensions.cs
@@ -28,7 +28,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, static (x, target) =>
+            return builder.Bind(visualElement, static (x, target) =>
             {
                 target.style.left = x;
             });
@@ -47,7 +47,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, static (x, target) =>
+            return builder.Bind(visualElement, static (x, target) =>
             {
                 target.style.right = x;
             });
@@ -66,7 +66,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, static (x, target) =>
+            return builder.Bind(visualElement, static (x, target) =>
             {
                 target.style.top = x;
             });
@@ -85,7 +85,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, static (x, target) =>
+            return builder.Bind(visualElement, static (x, target) =>
             {
                 target.style.bottom = x;
             });
@@ -104,7 +104,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, static (x, target) =>
+            return builder.Bind(visualElement, static (x, target) =>
             {
                 target.style.width = x;
             });
@@ -123,7 +123,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, static (x, target) =>
+            return builder.Bind(visualElement, static (x, target) =>
             {
                 target.style.height = x;
             });
@@ -142,7 +142,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Color, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, static (x, target) =>
+            return builder.Bind(visualElement, static (x, target) =>
             {
                 target.style.color = x;
             });
@@ -161,7 +161,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, static (x, target) =>
+            return builder.Bind(visualElement, static (x, target) =>
             {
                 var c = target.style.color.value;
                 c.r = x;
@@ -182,7 +182,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, static (x, target) =>
+            return builder.Bind(visualElement, static (x, target) =>
             {
                 var c = target.style.color.value;
                 c.g = x;
@@ -203,7 +203,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, static (x, target) =>
+            return builder.Bind(visualElement, static (x, target) =>
             {
                 var c = target.style.color.value;
                 c.b = x;
@@ -224,7 +224,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, static (x, target) =>
+            return builder.Bind(visualElement, static (x, target) =>
             {
                 var c = target.style.color.value;
                 c.a = x;
@@ -245,7 +245,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Color, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, static (x, target) =>
+            return builder.Bind(visualElement, static (x, target) =>
             {
                 target.style.backgroundColor = x;
             });
@@ -264,7 +264,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, static (x, target) =>
+            return builder.Bind(visualElement, static (x, target) =>
             {
                 var c = target.style.backgroundColor.value;
                 c.r = x;
@@ -285,7 +285,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, static (x, target) =>
+            return builder.Bind(visualElement, static (x, target) =>
             {
                 var c = target.style.backgroundColor.value;
                 c.g = x;
@@ -306,7 +306,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, static (x, target) =>
+            return builder.Bind(visualElement, static (x, target) =>
             {
                 var c = target.style.backgroundColor.value;
                 c.b = x;
@@ -327,7 +327,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, static (x, target) =>
+            return builder.Bind(visualElement, static (x, target) =>
             {
                 var c = target.style.backgroundColor.value;
                 c.a = x;
@@ -348,7 +348,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, static (x, target) =>
+            return builder.Bind(visualElement, static (x, target) =>
             {
                 target.style.opacity = x;
             });
@@ -367,7 +367,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, static (x, target) =>
+            return builder.Bind(visualElement, static (x, target) =>
             {
                 target.style.fontSize = x;
             });
@@ -386,7 +386,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, static (x, target) =>
+            return builder.Bind(visualElement, static (x, target) =>
             {
                 target.style.wordSpacing = x;
             });
@@ -405,7 +405,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector3, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, static (x, target) =>
+            return builder.Bind(visualElement, static (x, target) =>
             {
                 target.style.translate = new Translate(x.x, x.y, x.z);
             });
@@ -424,7 +424,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, static (x, target) =>
+            return builder.Bind(visualElement, static (x, target) =>
             {
                 target.style.translate = new Translate(x.x, x.y);
             });
@@ -443,7 +443,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, (x, target) =>
+            return builder.Bind(visualElement, (x, target) =>
             {
                 target.style.rotate = new Rotate(new Angle(x, angleUnit));
             });
@@ -462,7 +462,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector3, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, static (x, target) =>
+            return builder.Bind(visualElement, static (x, target) =>
             {
                 target.style.scale = new Scale(x);
             });
@@ -481,7 +481,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector3, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, static (x, target) =>
+            return builder.Bind(visualElement, static (x, target) =>
             {
                 target.style.transformOrigin = new TransformOrigin(x.x, x.y, x.z);
             });
@@ -500,7 +500,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
         {
             Error.IsNull(visualElement);
-            return builder.BindWithState(visualElement, static (x, target) =>
+            return builder.Bind(visualElement, static (x, target) =>
             {
                 target.style.transformOrigin = new TransformOrigin(x.x, x.y);
             });
@@ -523,7 +523,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(progressBar);
-            return builder.BindWithState(progressBar, static (x, target) =>
+            return builder.Bind(progressBar, static (x, target) =>
             {
                 target.value = x;
             });
@@ -546,7 +546,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<FixedString32Bytes, TOptions>
         {
             Error.IsNull(textElement);
-            return builder.BindWithState(textElement, static (x, target) =>
+            return builder.Bind(textElement, static (x, target) =>
             {
                 target.text = x.ConvertToString();
             });
@@ -565,7 +565,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<FixedString64Bytes, TOptions>
         {
             Error.IsNull(textElement);
-            return builder.BindWithState(textElement, static (x, target) =>
+            return builder.Bind(textElement, static (x, target) =>
             {
                 target.text = x.ConvertToString();
             });
@@ -584,7 +584,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<FixedString128Bytes, TOptions>
         {
             Error.IsNull(textElement);
-            return builder.BindWithState(textElement, static (x, target) =>
+            return builder.Bind(textElement, static (x, target) =>
             {
                 target.text = x.ConvertToString();
             });
@@ -603,7 +603,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<FixedString512Bytes, TOptions>
         {
             Error.IsNull(textElement);
-            return builder.BindWithState(textElement, static (x, target) =>
+            return builder.Bind(textElement, static (x, target) =>
             {
                 target.text = x.ConvertToString();
             });
@@ -622,7 +622,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<FixedString4096Bytes, TOptions>
         {
             Error.IsNull(textElement);
-            return builder.BindWithState(textElement, static (x, target) =>
+            return builder.Bind(textElement, static (x, target) =>
             {
                 target.text = x.ConvertToString();
             });
@@ -641,7 +641,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<int, TOptions>
         {
             Error.IsNull(textElement);
-            return builder.BindWithState(textElement, static (x, target) =>
+            return builder.Bind(textElement, static (x, target) =>
             {
                 target.text = x.ToString();
             });
@@ -661,7 +661,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<int, TOptions>
         {
             Error.IsNull(textElement);
-            return builder.BindWithState((textElement, format), static (x, state) =>
+            return builder.Bind((textElement, format), static (x, state) =>
             {
 #if LITMOTION_SUPPORT_ZSTRING
                 state.textElement.text = ZString.Format(state.format, x);
@@ -684,7 +684,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<long, TOptions>
         {
             Error.IsNull(textElement);
-            return builder.BindWithState(textElement, static (x, target) =>
+            return builder.Bind(textElement, static (x, target) =>
             {
                 target.text = x.ToString();
             });
@@ -704,7 +704,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<long, TOptions>
         {
             Error.IsNull(textElement);
-            return builder.BindWithState((textElement, format), static (x, state) =>
+            return builder.Bind((textElement, format), static (x, state) =>
             {
 #if LITMOTION_SUPPORT_ZSTRING
                 state.textElement.text = ZString.Format(state.format, x);
@@ -727,7 +727,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(textElement);
-            return builder.BindWithState(textElement, static (x, target) =>
+            return builder.Bind(textElement, static (x, target) =>
             {
                 target.text = x.ToString();
             });
@@ -747,7 +747,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(textElement);
-            return builder.BindWithState((textElement, format), static (x, state) =>
+            return builder.Bind((textElement, format), static (x, state) =>
             {
 #if LITMOTION_SUPPORT_ZSTRING
                 state.textElement.text = ZString.Format(state.format, x);

--- a/src/LitMotion/Assets/LitMotion/Runtime/Extensions/VisualEffectGragh/LitMotionVisualEffectExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Extensions/VisualEffectGragh/LitMotionVisualEffectExtensions.cs
@@ -22,9 +22,9 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(visualEffect);
-            return builder.BindWithState(visualEffect, name, static (x, target, n) =>
+            return builder.BindWithState((visualEffect, name), static (x, state) =>
             {
-                target.SetFloat(n, x);
+                state.visualEffect.SetFloat(state.name, x);
             });
         }
 
@@ -60,9 +60,9 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<int, TOptions>
         {
             Error.IsNull(visualEffect);
-            return builder.BindWithState(visualEffect, name, static (x, target, n) =>
+            return builder.BindWithState((visualEffect, name), static (x, state) =>
             {
-                target.SetInt(n, x);
+                state.visualEffect.SetInt(state.name, x);
             });
         }
 
@@ -98,9 +98,9 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
         {
             Error.IsNull(visualEffect);
-            return builder.BindWithState(visualEffect, name, static (x, target, n) =>
+            return builder.BindWithState((visualEffect, name), static (x, state) =>
             {
-                target.SetVector2(n, x);
+                state.visualEffect.SetVector2(state.name, x);
             });
         }
 
@@ -136,9 +136,9 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector3, TOptions>
         {
             Error.IsNull(visualEffect);
-            return builder.BindWithState(visualEffect, name, static (x, target, n) =>
+            return builder.BindWithState((visualEffect, name), static (x, state) =>
             {
-                target.SetVector3(n, x);
+                state.visualEffect.SetVector3(state.name, x);
             });
         }
 
@@ -174,9 +174,9 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector4, TOptions>
         {
             Error.IsNull(visualEffect);
-            return builder.BindWithState(visualEffect, name, static (x, target, n) =>
+            return builder.BindWithState((visualEffect, name), static (x, state) =>
             {
-                target.SetVector4(n, x);
+                state.visualEffect.SetVector4(state.name, x);
             });
         }
 

--- a/src/LitMotion/Assets/LitMotion/Runtime/Extensions/VisualEffectGragh/LitMotionVisualEffectExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Extensions/VisualEffectGragh/LitMotionVisualEffectExtensions.cs
@@ -22,7 +22,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(visualEffect);
-            return builder.BindWithState((visualEffect, name), static (x, state) =>
+            return builder.Bind((visualEffect, name), static (x, state) =>
             {
                 state.visualEffect.SetFloat(state.name, x);
             });
@@ -41,7 +41,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(visualEffect);
-            return builder.BindWithState(visualEffect, (x, target) =>
+            return builder.Bind(visualEffect, (x, target) =>
             {
                 target.SetFloat(nameID, x);
             });
@@ -60,7 +60,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<int, TOptions>
         {
             Error.IsNull(visualEffect);
-            return builder.BindWithState((visualEffect, name), static (x, state) =>
+            return builder.Bind((visualEffect, name), static (x, state) =>
             {
                 state.visualEffect.SetInt(state.name, x);
             });
@@ -79,7 +79,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<int, TOptions>
         {
             Error.IsNull(visualEffect);
-            return builder.BindWithState(visualEffect, (x, target) =>
+            return builder.Bind(visualEffect, (x, target) =>
             {
                 target.SetFloat(nameID, x);
             });
@@ -98,7 +98,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
         {
             Error.IsNull(visualEffect);
-            return builder.BindWithState((visualEffect, name), static (x, state) =>
+            return builder.Bind((visualEffect, name), static (x, state) =>
             {
                 state.visualEffect.SetVector2(state.name, x);
             });
@@ -117,7 +117,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
         {
             Error.IsNull(visualEffect);
-            return builder.BindWithState(visualEffect, (x, target) =>
+            return builder.Bind(visualEffect, (x, target) =>
             {
                 target.SetVector2(nameID, x);
             });
@@ -136,7 +136,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector3, TOptions>
         {
             Error.IsNull(visualEffect);
-            return builder.BindWithState((visualEffect, name), static (x, state) =>
+            return builder.Bind((visualEffect, name), static (x, state) =>
             {
                 state.visualEffect.SetVector3(state.name, x);
             });
@@ -155,7 +155,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector3, TOptions>
         {
             Error.IsNull(visualEffect);
-            return builder.BindWithState(visualEffect, (x, target) =>
+            return builder.Bind(visualEffect, (x, target) =>
             {
                 target.SetVector3(nameID, x);
             });
@@ -174,7 +174,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector4, TOptions>
         {
             Error.IsNull(visualEffect);
-            return builder.BindWithState((visualEffect, name), static (x, state) =>
+            return builder.Bind((visualEffect, name), static (x, state) =>
             {
                 state.visualEffect.SetVector4(state.name, x);
             });
@@ -193,7 +193,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector4, TOptions>
         {
             Error.IsNull(visualEffect);
-            return builder.BindWithState(visualEffect, (x, target) =>
+            return builder.Bind(visualEffect, (x, target) =>
             {
                 target.SetVector4(nameID, x);
             });

--- a/src/LitMotion/Assets/LitMotion/Runtime/Extensions/uGUI/LitMotionRectTransformExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Extensions/uGUI/LitMotionRectTransformExtensions.cs
@@ -20,7 +20,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
         {
             Error.IsNull(rectTransform);
-            return builder.BindWithState(rectTransform, static (x, target) =>
+            return builder.Bind(rectTransform, static (x, target) =>
             {
                 target.anchoredPosition = x;
             });
@@ -39,7 +39,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(rectTransform);
-            return builder.BindWithState(rectTransform, static (x, target) =>
+            return builder.Bind(rectTransform, static (x, target) =>
             {
                 var p = target.anchoredPosition;
                 p.x = x;
@@ -60,7 +60,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(rectTransform);
-            return builder.BindWithState(rectTransform, static (x, target) =>
+            return builder.Bind(rectTransform, static (x, target) =>
             {
                 var p = target.anchoredPosition;
                 p.y = x;
@@ -81,7 +81,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector3, TOptions>
         {
             Error.IsNull(rectTransform);
-            return builder.BindWithState(rectTransform, static (x, target) =>
+            return builder.Bind(rectTransform, static (x, target) =>
             {
                 target.anchoredPosition3D = x;
             });
@@ -100,7 +100,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(rectTransform);
-            return builder.BindWithState(rectTransform, static (x, target) =>
+            return builder.Bind(rectTransform, static (x, target) =>
             {
                 var p = target.anchoredPosition3D;
                 p.x = x;
@@ -121,7 +121,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(rectTransform);
-            return builder.BindWithState(rectTransform, static (x, target) =>
+            return builder.Bind(rectTransform, static (x, target) =>
             {
                 var p = target.anchoredPosition3D;
                 p.y = x;
@@ -142,7 +142,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(rectTransform);
-            return builder.BindWithState(rectTransform, static (x, target) =>
+            return builder.Bind(rectTransform, static (x, target) =>
             {
                 var p = target.anchoredPosition3D;
                 p.z = x;
@@ -163,7 +163,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
         {
             Error.IsNull(rectTransform);
-            return builder.BindWithState(rectTransform, static (x, target) =>
+            return builder.Bind(rectTransform, static (x, target) =>
             {
                 target.anchorMin = x;
             });
@@ -182,7 +182,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
         {
             Error.IsNull(rectTransform);
-            return builder.BindWithState(rectTransform, static (x, target) =>
+            return builder.Bind(rectTransform, static (x, target) =>
             {
                 target.anchorMax = x;
             });
@@ -202,7 +202,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
         {
             Error.IsNull(rectTransform);
-            return builder.BindWithState(rectTransform, static (x, target) =>
+            return builder.Bind(rectTransform, static (x, target) =>
             {
                 target.sizeDelta = x;
             });
@@ -221,7 +221,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(rectTransform);
-            return builder.BindWithState(rectTransform, static (x, target) =>
+            return builder.Bind(rectTransform, static (x, target) =>
             {
                 var s = target.sizeDelta;
                 s.x = x;
@@ -242,7 +242,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(rectTransform);
-            return builder.BindWithState(rectTransform, static (x, target) =>
+            return builder.Bind(rectTransform, static (x, target) =>
             {
                 var s = target.sizeDelta;
                 s.y = x;
@@ -263,7 +263,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Vector2, TOptions>
         {
             Error.IsNull(rectTransform);
-            return builder.BindWithState(rectTransform, static (x, target) =>
+            return builder.Bind(rectTransform, static (x, target) =>
             {
                 target.pivot = x;
             });
@@ -282,7 +282,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(rectTransform);
-            return builder.BindWithState(rectTransform, static (x, target) =>
+            return builder.Bind(rectTransform, static (x, target) =>
             {
                 var s = target.pivot;
                 s.x = x;
@@ -303,7 +303,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(rectTransform);
-            return builder.BindWithState(rectTransform, static (x, target) =>
+            return builder.Bind(rectTransform, static (x, target) =>
             {
                 var s = target.pivot;
                 s.y = x;

--- a/src/LitMotion/Assets/LitMotion/Runtime/Extensions/uGUI/LitMotionUGUIExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Extensions/uGUI/LitMotionUGUIExtensions.cs
@@ -301,12 +301,12 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<int, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, format, static (x, target, format) =>
+            return builder.BindWithState((text, format), static (x, state) =>
             {
 #if LITMOTION_SUPPORT_ZSTRING
-                target.text = ZString.Format(format, x);
+                state.text.text = ZString.Format(state.format, x);
 #else
-                target.text = string.Format(format, x);
+                state.text.text = string.Format(state.format, x);
 #endif
             });
         }
@@ -344,12 +344,12 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<long, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, format, static (x, target, format) =>
+            return builder.BindWithState((text, format), static (x, state) =>
             {
 #if LITMOTION_SUPPORT_ZSTRING
-                target.text = ZString.Format(format, x);
+                state.text.text = ZString.Format(state.format, x);
 #else
-                target.text = string.Format(format, x);
+                state.text.text = string.Format(state.format, x);
 #endif
             });
         }
@@ -387,12 +387,12 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, format, static (x, target, format) =>
+            return builder.BindWithState((text, format), static (x, state) =>
             {
 #if LITMOTION_SUPPORT_ZSTRING
-                target.text = ZString.Format(format, x);
+                state.text.text = ZString.Format(state.format, x);
 #else
-                target.text = string.Format(format, x);
+                state.text.text = string.Format(state.format, x);
 #endif
             });
         }

--- a/src/LitMotion/Assets/LitMotion/Runtime/Extensions/uGUI/LitMotionUGUIExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Extensions/uGUI/LitMotionUGUIExtensions.cs
@@ -26,7 +26,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<Color, TOptions>
         {
             Error.IsNull(graphic);
-            return builder.BindWithState(graphic, static (x, target) =>
+            return builder.Bind(graphic, static (x, target) =>
             {
                 target.color = x;
             });
@@ -45,7 +45,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(graphic);
-            return builder.BindWithState(graphic, static (x, target) =>
+            return builder.Bind(graphic, static (x, target) =>
             {
                 var c = target.color;
                 c.r = x;
@@ -66,7 +66,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(graphic);
-            return builder.BindWithState(graphic, static (x, target) =>
+            return builder.Bind(graphic, static (x, target) =>
             {
                 var c = target.color;
                 c.g = x;
@@ -87,7 +87,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(graphic);
-            return builder.BindWithState(graphic, static (x, target) =>
+            return builder.Bind(graphic, static (x, target) =>
             {
                 var c = target.color;
                 c.b = x;
@@ -108,7 +108,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(graphic);
-            return builder.BindWithState(graphic, static (x, target) =>
+            return builder.Bind(graphic, static (x, target) =>
             {
                 var c = target.color;
                 c.a = x;
@@ -129,7 +129,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(image);
-            return builder.BindWithState(image, static (x, target) =>
+            return builder.Bind(image, static (x, target) =>
             {
                 target.fillAmount = x;
             });
@@ -148,7 +148,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(canvasGroup);
-            return builder.BindWithState(canvasGroup, static (x, target) =>
+            return builder.Bind(canvasGroup, static (x, target) =>
             {
                 target.alpha = x;
             });
@@ -167,7 +167,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<int, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, static (x, target) =>
+            return builder.Bind(text, static (x, target) =>
             {
                 target.fontSize = x;
             });
@@ -186,7 +186,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<FixedString32Bytes, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, static (x, target) =>
+            return builder.Bind(text, static (x, target) =>
             {
                 target.text = x.ConvertToString();
             });
@@ -205,7 +205,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<FixedString64Bytes, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, static (x, target) =>
+            return builder.Bind(text, static (x, target) =>
             {
                 target.text = x.ConvertToString();
             });
@@ -224,7 +224,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<FixedString128Bytes, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, static (x, target) =>
+            return builder.Bind(text, static (x, target) =>
             {
                 target.text = x.ConvertToString();
             });
@@ -243,7 +243,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<FixedString512Bytes, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, static (x, target) =>
+            return builder.Bind(text, static (x, target) =>
             {
                 target.text = x.ConvertToString();
             });
@@ -262,7 +262,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<FixedString4096Bytes, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, static (x, target) =>
+            return builder.Bind(text, static (x, target) =>
             {
                 target.text = x.ConvertToString();
             });
@@ -281,7 +281,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<int, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, static (x, target) =>
+            return builder.Bind(text, static (x, target) =>
             {
                 target.text = x.ToString();
             });
@@ -301,7 +301,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<int, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState((text, format), static (x, state) =>
+            return builder.Bind((text, format), static (x, state) =>
             {
 #if LITMOTION_SUPPORT_ZSTRING
                 state.text.text = ZString.Format(state.format, x);
@@ -324,7 +324,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<long, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, static (x, target) =>
+            return builder.Bind(text, static (x, target) =>
             {
                 target.text = x.ToString();
             });
@@ -344,7 +344,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<long, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState((text, format), static (x, state) =>
+            return builder.Bind((text, format), static (x, state) =>
             {
 #if LITMOTION_SUPPORT_ZSTRING
                 state.text.text = ZString.Format(state.format, x);
@@ -367,7 +367,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState(text, static (x, target) =>
+            return builder.Bind(text, static (x, target) =>
             {
                 target.text = x.ToString();
             });
@@ -387,7 +387,7 @@ namespace LitMotion.Extensions
             where TAdapter : unmanaged, IMotionAdapter<float, TOptions>
         {
             Error.IsNull(text);
-            return builder.BindWithState((text, format), static (x, state) =>
+            return builder.Bind((text, format), static (x, state) =>
             {
 #if LITMOTION_SUPPORT_ZSTRING
                 state.text.text = ZString.Format(state.format, x);

--- a/src/LitMotion/Assets/LitMotion/Runtime/External/R3/LitMotionR3Extensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/External/R3/LitMotionR3Extensions.cs
@@ -41,7 +41,7 @@ namespace LitMotion
             where TAdapter : unmanaged, IMotionAdapter<TValue, TOptions>
         {
             Error.IsNull(reactiveProperty);
-            return builder.BindWithState(reactiveProperty, static (x, target) =>
+            return builder.Bind(reactiveProperty, static (x, target) =>
             {
                 target.Value = x;
             });

--- a/src/LitMotion/Assets/LitMotion/Runtime/External/R3/LitMotionR3Extensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/External/R3/LitMotionR3Extensions.cs
@@ -22,7 +22,7 @@ namespace LitMotion
             builder.SetCallbackData(subject, static (x, subject) => subject.OnNext(x));
             builder.buffer.OnCompleteAction += () => subject.OnCompleted();
             builder.buffer.OnCancelAction += () => subject.OnCompleted();
-            builder.ScheduleCore();
+            builder.ScheduleMotion();
             return subject;
         }
 

--- a/src/LitMotion/Assets/LitMotion/Runtime/External/UniRx/LitMotionUniRxExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/External/UniRx/LitMotionUniRxExtensions.cs
@@ -45,7 +45,7 @@ namespace LitMotion
             where TAdapter : unmanaged, IMotionAdapter<TValue, TOptions>
         {
             Error.IsNull(reactiveProperty);
-            return builder.BindWithState(reactiveProperty, static (x, target) =>
+            return builder.Bind(reactiveProperty, static (x, target) =>
             {
                 target.Value = x;
             });

--- a/src/LitMotion/Assets/LitMotion/Runtime/External/UniRx/LitMotionUniRxExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/External/UniRx/LitMotionUniRxExtensions.cs
@@ -26,7 +26,7 @@ namespace LitMotion
             builder.SetCallbackData(subject, static (x, subject) => subject.OnNext(x));
             builder.buffer.OnCompleteAction += () => subject.OnCompleted();
             builder.buffer.OnCancelAction += () => subject.OnCompleted();
-            builder.ScheduleCore();
+            builder.ScheduleMotion();
             return subject;
         }
 

--- a/src/LitMotion/Assets/LitMotion/Runtime/External/UniTask/LitMotionUniTaskExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/External/UniTask/LitMotionUniTaskExtensions.cs
@@ -63,7 +63,7 @@ namespace LitMotion
             where TAdapter : unmanaged, IMotionAdapter<TValue, TOptions>
         {
             Error.IsNull(reactiveProperty);
-            return builder.BindWithState(reactiveProperty, static (x, target) =>
+            return builder.Bind(reactiveProperty, static (x, target) =>
             {
                 target.Value = x;
             });

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/ActionWithState.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/ActionWithState.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace LitMotion
+{
+    internal sealed record ActionWithState<TValue, TState>
+        where TValue : unmanaged
+        where TState : struct
+    {
+        public ActionWithState(TState state, Action<TValue, TState> action)
+        {
+            this.state = state;
+            this.action = action;
+        }
+
+        readonly TState state;
+        readonly Action<TValue, TState> action;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Invoke(TValue value)
+        {
+            action(value, state);
+        }
+    }
+}

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/ActionWithState.cs.meta
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/ActionWithState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a1a9468e2ee624ed3b644c7610741c29

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/ManagedMotionData.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/ManagedMotionData.cs
@@ -11,13 +11,10 @@ namespace LitMotion
     [StructLayout(LayoutKind.Auto)]
     public struct ManagedMotionData
     {
-        public byte StateCount;
         public bool IsCallbackRunning;
         public bool CancelOnError;
         public bool SkipValuesDuringDelay;
-        public object State1;
-        public object State2;
-        public object State3;
+        public object State;
 
         public object UpdateAction;
         public Action OnCompleteAction;
@@ -26,20 +23,13 @@ namespace LitMotion
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void InvokeUnsafe<TValue>(in TValue value) where TValue : unmanaged
         {
-            switch (StateCount)
+            if (State != null)
             {
-                case 0:
-                    UnsafeUtility.As<object, Action<TValue>>(ref UpdateAction)?.Invoke(value);
-                    break;
-                case 1:
-                    UnsafeUtility.As<object, Action<TValue, object>>(ref UpdateAction)?.Invoke(value, State1);
-                    break;
-                case 2:
-                    UnsafeUtility.As<object, Action<TValue, object, object>>(ref UpdateAction)?.Invoke(value, State1, State2);
-                    break;
-                case 3:
-                    UnsafeUtility.As<object, Action<TValue, object, object, object>>(ref UpdateAction)?.Invoke(value, State1, State2, State3);
-                    break;
+                UnsafeUtility.As<object, Action<TValue>>(ref UpdateAction)?.Invoke(value);
+            }
+            else
+            {
+                UnsafeUtility.As<object, Action<TValue, object>>(ref UpdateAction)?.Invoke(value, State);
             }
         }
 

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/ManagedMotionData.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/ManagedMotionData.cs
@@ -21,7 +21,7 @@ namespace LitMotion
         public Action OnCancelAction;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void InvokeUnsafe<TValue>(in TValue value) where TValue : unmanaged
+        public void UpdateUnsafe<TValue>(in TValue value) where TValue : unmanaged
         {
             if (State != null)
             {
@@ -30,6 +30,19 @@ namespace LitMotion
             else
             {
                 UnsafeUtility.As<object, Action<TValue, object>>(ref UpdateAction)?.Invoke(value, State);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void InvokeCancel()
+        {
+            try
+            {
+                OnCancelAction?.Invoke();
+            }
+            catch (Exception ex)
+            {
+                MotionDispatcher.GetUnhandledExceptionHandler()?.Invoke(ex);
             }
         }
 

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/ManagedMotionData.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/ManagedMotionData.cs
@@ -23,7 +23,7 @@ namespace LitMotion
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void UpdateUnsafe<TValue>(in TValue value) where TValue : unmanaged
         {
-            if (State != null)
+            if (State == null)
             {
                 UnsafeUtility.As<object, Action<TValue>>(ref UpdateAction)?.Invoke(value);
             }

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionStorage.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionStorage.cs
@@ -106,10 +106,7 @@ namespace LitMotion
             managedDataRef.OnCancelAction = buffer.OnCancelAction;
             managedDataRef.OnCompleteAction = buffer.OnCompleteAction;
             managedDataRef.SkipValuesDuringDelay = buffer.SkipValuesDuringDelay;
-            managedDataRef.State1 = buffer.State1;
-            managedDataRef.State2 = buffer.State2;
-            managedDataRef.State3 = buffer.State3;
-            managedDataRef.StateCount = buffer.StateCount;
+            managedDataRef.State = buffer.State;
 
             if (buffer.BindOnSchedule && buffer.UpdateAction != null)
             {

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionStorage.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionStorage.cs
@@ -110,7 +110,7 @@ namespace LitMotion
 
             if (buffer.BindOnSchedule && buffer.UpdateAction != null)
             {
-                managedDataRef.InvokeUnsafe(
+                managedDataRef.UpdateUnsafe(
                     default(TAdapter).Evaluate(
                         ref dataRef.StartValue,
                         ref dataRef.EndValue,
@@ -285,7 +285,7 @@ namespace LitMotion
                     new() { Progress = easedEndProgress }
                 );
 
-                managedData.InvokeUnsafe(endValue);
+                managedData.UpdateUnsafe(endValue);
             }
             catch (Exception ex)
             {

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/UpdateRunner.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/UpdateRunner.cs
@@ -68,7 +68,7 @@ namespace LitMotion
                     {
                         try
                         {
-                            managedData.InvokeUnsafe(outputPtr[i]);
+                            managedData.UpdateUnsafe(outputPtr[i]);
                         }
                         catch (Exception ex)
                         {
@@ -84,7 +84,7 @@ namespace LitMotion
                     {
                         try
                         {
-                            managedData.InvokeUnsafe(outputPtr[i]);
+                            managedData.UpdateUnsafe(outputPtr[i]);
                         }
                         catch (Exception ex)
                         {

--- a/src/LitMotion/Assets/LitMotion/Runtime/MotionBuilder.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/MotionBuilder.cs
@@ -31,7 +31,7 @@ namespace LitMotion
             buffer.Version++;
             buffer.IsPreserved = false;
             buffer.BindOnSchedule = false;
-            
+
             buffer.StartValue = default;
             buffer.EndValue = default;
             buffer.Options = default;
@@ -44,10 +44,7 @@ namespace LitMotion
             buffer.Loops = 1;
             buffer.LoopType = default;
 
-            buffer.StateCount = 0;
-            buffer.State1 = default;
-            buffer.State2 = default;
-            buffer.State3 = default;
+            buffer.State = default;
             buffer.UpdateAction = default;
             buffer.OnCompleteAction = default;
             buffer.OnCancelAction = default;
@@ -79,12 +76,9 @@ namespace LitMotion
         public int Loops = 1;
         public DelayType DelayType;
         public LoopType LoopType;
-        public byte StateCount;
         public bool CancelOnError;
         public bool SkipValuesDuringDelay;
-        public object State1;
-        public object State2;
-        public object State3;
+        public object State;
         public object UpdateAction;
         public Action OnCompleteAction;
         public Action OnCancelAction;
@@ -287,43 +281,6 @@ namespace LitMotion
         }
 
         /// <summary>
-        /// Create motion and bind it to a specific object. Unlike the regular Bind method, it avoids allocation by closure by passing an object.
-        /// </summary>
-        /// <typeparam name="TState1">Type of state</typeparam>
-        /// <typeparam name="TState2">Type of state</typeparam>
-        /// <param name="state">Motion state</param>
-        /// <param name="action">Action that handles binding</param>
-        /// <returns>Handle of the created motion data.</returns>
-        public MotionHandle BindWithState<TState1, TState2>(TState1 state1, TState2 state2, Action<TValue, TState1, TState2> action)
-            where TState1 : class
-            where TState2 : class
-        {
-            CheckBuffer();
-            SetCallbackData(state1, state2, action);
-            return ScheduleCore();
-        }
-
-
-        /// <summary>
-        /// Create motion and bind it to a specific object. Unlike the regular Bind method, it avoids allocation by closure by passing an object.
-        /// </summary>
-        /// <typeparam name="TState1">Type of state</typeparam>
-        /// <typeparam name="TState2">Type of state</typeparam>
-        /// <typeparam name="TState3">Type of state</typeparam>
-        /// <param name="state">Motion state</param>
-        /// <param name="action">Action that handles binding</param>
-        /// <returns>Handle of the created motion data.</returns>
-        public MotionHandle BindWithState<TState1, TState2, TState3>(TState1 state1, TState2 state2, TState3 state3, Action<TValue, TState1, TState2, TState3> action)
-            where TState1 : class
-            where TState2 : class
-            where TState3 : class
-        {
-            CheckBuffer();
-            SetCallbackData(state1, state2, state3, action);
-            return ScheduleCore();
-        }
-
-        /// <summary>
         /// Preserves the internal buffer and prevents the builder from being automatically destroyed after creating the motion data.
         /// Calling this allows you to create the motion multiple times, but you must call the Dispose method to destroy the builder after use.
         /// </summary>
@@ -402,32 +359,7 @@ namespace LitMotion
         internal readonly void SetCallbackData<TState>(TState state, Action<TValue, TState> action)
             where TState : class
         {
-            buffer.StateCount = 1;
-            buffer.State1 = state;
-            buffer.UpdateAction = action;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal readonly void SetCallbackData<TState1, TState2>(TState1 state1, TState2 state2, Action<TValue, TState1, TState2> action)
-            where TState1 : class
-            where TState2 : class
-        {
-            buffer.StateCount = 2;
-            buffer.State1 = state1;
-            buffer.State2 = state2;
-            buffer.UpdateAction = action;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal readonly void SetCallbackData<TState1, TState2, TState3>(TState1 state1, TState2 state2, TState3 state3, Action<TValue, TState1, TState2, TState3> action)
-            where TState1 : class
-            where TState2 : class
-            where TState3 : class
-        {
-            buffer.StateCount = 3;
-            buffer.State1 = state1;
-            buffer.State2 = state2;
-            buffer.State3 = state3;
+            buffer.State = state;
             buffer.UpdateAction = action;
         }
 

--- a/src/LitMotion/Assets/LitMotion/Runtime/MotionBuilder.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/MotionBuilder.cs
@@ -251,7 +251,7 @@ namespace LitMotion
         public MotionHandle RunWithoutBinding()
         {
             CheckBuffer();
-            return ScheduleCore();
+            return ScheduleMotion();
         }
 
         /// <summary>
@@ -263,7 +263,7 @@ namespace LitMotion
         {
             CheckBuffer();
             SetCallbackData(action);
-            return ScheduleCore();
+            return ScheduleMotion();
         }
 
         /// <summary>
@@ -278,7 +278,7 @@ namespace LitMotion
         {
             CheckBuffer();
             SetCallbackData(state, action);
-            return ScheduleCore();
+            return ScheduleMotion();
         }
 
         /// <summary>
@@ -295,7 +295,7 @@ namespace LitMotion
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal MotionHandle ScheduleCore()
+        internal MotionHandle ScheduleMotion()
         {
             MotionHandle handle;
 

--- a/src/LitMotion/Assets/LitMotion/Runtime/MotionBuilder.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/MotionBuilder.cs
@@ -273,7 +273,8 @@ namespace LitMotion
         /// <param name="state">Motion state</param>
         /// <param name="action">Action that handles binding</param>
         /// <returns>Handle of the created motion data.</returns>
-        public MotionHandle BindWithState<TState>(TState state, Action<TValue, TState> action) where TState : class
+        public MotionHandle Bind<TState>(TState state, Action<TValue, TState> action)
+            where TState : class
         {
             CheckBuffer();
             SetCallbackData(state, action);

--- a/src/LitMotion/Assets/LitMotion/Runtime/MotionBuilderExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/MotionBuilderExtensions.cs
@@ -16,13 +16,13 @@ namespace LitMotion
         /// <param name="state">Motion state</param>
         /// <param name="action">Action that handles binding</param>
         /// <returns>Handle of the created motion data.</returns>
-        public static MotionHandle BindWithState<TValue, TOptions, TAdapter, TState>(this MotionBuilder<TValue, TOptions, TAdapter> builder, TState state, Action<TValue, TState> action)
+        public static MotionHandle Bind<TValue, TOptions, TAdapter, TState>(this MotionBuilder<TValue, TOptions, TAdapter> builder, TState state, Action<TValue, TState> action)
             where TValue : unmanaged
             where TOptions : unmanaged, IMotionOptions
             where TAdapter : unmanaged, IMotionAdapter<TValue, TOptions>
             where TState : struct
         {
-            return builder.BindWithState(new ActionWithState<TValue, TState>(state, action), (x, state) => state.Invoke(x));
+            return builder.Bind(new ActionWithState<TValue, TState>(state, action), (x, state) => state.Invoke(x));
         }
 
         /// <summary>
@@ -40,7 +40,7 @@ namespace LitMotion
             where TAdapter : unmanaged, IMotionAdapter<TValue, TOptions>
         {
             Error.IsNull(progress);
-            return builder.BindWithState(progress, static (x, progress) => progress.Report(x));
+            return builder.Bind(progress, static (x, progress) => progress.Report(x));
         }
 
         /// <summary>
@@ -73,7 +73,7 @@ namespace LitMotion
             where TAdapter : unmanaged, IMotionAdapter<TValue, TOptions>
         {
             Error.IsNull(logger);
-            return builder.BindWithState(logger, static (x, logger) => logger.Log(x));
+            return builder.Bind(logger, static (x, logger) => logger.Log(x));
         }
 
         /// <summary>

--- a/src/LitMotion/Assets/LitMotion/Runtime/MotionBuilderExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/MotionBuilderExtensions.cs
@@ -10,6 +10,22 @@ namespace LitMotion
     public static class MotionBuilderExtensions
     {
         /// <summary>
+        /// Create motion and bind it to a specific object. Unlike the regular Bind method, it avoids allocation by closure by passing an object.
+        /// </summary>
+        /// <typeparam name="TState">Type of state</typeparam>
+        /// <param name="state">Motion state</param>
+        /// <param name="action">Action that handles binding</param>
+        /// <returns>Handle of the created motion data.</returns>
+        public static MotionHandle BindWithState<TValue, TOptions, TAdapter, TState>(this MotionBuilder<TValue, TOptions, TAdapter> builder, TState state, Action<TValue, TState> action)
+            where TValue : unmanaged
+            where TOptions : unmanaged, IMotionOptions
+            where TAdapter : unmanaged, IMotionAdapter<TValue, TOptions>
+            where TState : struct
+        {
+            return builder.BindWithState(new ActionWithState<TValue, TState>(state, action), (x, state) => state.Invoke(x));
+        }
+
+        /// <summary>
         /// Create a motion data and bind it to IProgress
         /// </summary>
         /// <typeparam name="TValue">The type of value to animate</typeparam>

--- a/src/LitMotion/Assets/LitMotion/Tests/Runtime/BindTest.cs
+++ b/src/LitMotion/Assets/LitMotion/Tests/Runtime/BindTest.cs
@@ -32,33 +32,17 @@ namespace LitMotion.Tests.Runtime
         }
 
         [UnityTest]
-        public IEnumerator Test_BindWithState_2()
-        {
-            var target1 = new TestClass();
-            var target2 = new TestClass();
-            var endValue = 10f;
-            LMotion.Create(0f, endValue, 0.5f).BindWithState(target1, target2, (x, target1, target2) =>
-            {
-                target1.Value = x;
-                target2.Value = x;
-            });
-            yield return new WaitForSeconds(0.6f);
-            Assert.AreApproximatelyEqual(target1.Value, endValue);
-            Assert.AreApproximatelyEqual(target2.Value, endValue);
-        }
-
-        [UnityTest]
-        public IEnumerator Test_BindWithState_3()
+        public IEnumerator Test_BindWithState_Struct()
         {
             var target1 = new TestClass();
             var target2 = new TestClass();
             var target3 = new TestClass();
             var endValue = 10f;
-            LMotion.Create(0f, endValue, 0.5f).BindWithState(target1, target2, target3, (x, target1, target2, target3) =>
+            LMotion.Create(0f, endValue, 0.5f).BindWithState((target1, target2, target3), (x, state) =>
             {
-                target1.Value = x;
-                target2.Value = x;
-                target3.Value = x;
+                state.target1.Value = x;
+                state.target2.Value = x;
+                state.target3.Value = x;
             });
             yield return new WaitForSeconds(0.6f);
             Assert.AreApproximatelyEqual(target1.Value, endValue);

--- a/src/LitMotion/Assets/LitMotion/Tests/Runtime/BindTest.cs
+++ b/src/LitMotion/Assets/LitMotion/Tests/Runtime/BindTest.cs
@@ -23,7 +23,7 @@ namespace LitMotion.Tests.Runtime
         {
             var target = new TestClass();
             var endValue = 10f;
-            LMotion.Create(0f, endValue, 0.5f).BindWithState(target, (x, target) => 
+            LMotion.Create(0f, endValue, 0.5f).Bind(target, (x, target) =>
             {
                 target.Value = x;
             });
@@ -38,7 +38,7 @@ namespace LitMotion.Tests.Runtime
             var target2 = new TestClass();
             var target3 = new TestClass();
             var endValue = 10f;
-            LMotion.Create(0f, endValue, 0.5f).BindWithState((target1, target2, target3), (x, state) =>
+            LMotion.Create(0f, endValue, 0.5f).Bind((target1, target2, target3), (x, state) =>
             {
                 state.target1.Value = x;
                 state.target2.Value = x;


### PR DESCRIPTION
Change the name of the `BindWithState` method to `Bind`.

Also, add an overload that supports value-type state using a wrapper class for Action. This will result in fewer allocations, as closures are no longer needed. It also optimizes delegate calls, which improves performance. (See #71 )