### PR TITLE
Add `TryCancel` / `TryComplete`

### DIFF
--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/Error.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/Error.cs
@@ -33,7 +33,12 @@ namespace LitMotion
 
         public static void MotionNotExists()
         {
-            throw new ArgumentException("Motion has been destroyed or no longer exists.");
+            throw new InvalidOperationException("Motion has been destroyed or no longer exists.");
+        }
+
+        public static void MotionHasBeenCanceledOrCompleted()
+        {
+            throw new InvalidOperationException("Motion has already been canceled or completed.");
         }
     }
 }

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/Error.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/Error.cs
@@ -30,5 +30,10 @@ namespace LitMotion
         {
             throw new ArgumentOutOfRangeException("Playback speed must be 0 or greater.");
         }
+
+        public static void MotionNotExists()
+        {
+            throw new ArgumentException("Motion has been destroyed or no longer exists.");
+        }
     }
 }

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/ManagedMotionData.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/ManagedMotionData.cs
@@ -11,7 +11,6 @@ namespace LitMotion
     [StructLayout(LayoutKind.Auto)]
     public unsafe struct ManagedMotionData
     {
-        public bool IsCallbackRunning;
         public bool CancelOnError;
         public bool SkipValuesDuringDelay;
         public byte StateCount;

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionManager.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionManager.cs
@@ -37,16 +37,13 @@ namespace LitMotion
         public static void Complete(MotionHandle handle)
         {
             CheckTypeId(handle);
-            if (!list[handle.StorageId].TryComplete(handle))
-            {
-                Error.MotionNotExists();
-            }
+            list[handle.StorageId].Complete(handle);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryComplete(MotionHandle handle)
         {
-            if (handle.StorageId < 0 || handle.StorageId >= MotionTypeCount) return false;
+            CheckTypeId(handle);
             return list[handle.StorageId].TryComplete(handle);
         }
 
@@ -54,16 +51,13 @@ namespace LitMotion
         public static void Cancel(MotionHandle handle)
         {
             CheckTypeId(handle);
-            if (!list[handle.StorageId].TryCancel(handle))
-            {
-                Error.MotionNotExists();
-            }
+            list[handle.StorageId].Cancel(handle);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryCancel(MotionHandle handle)
         {
-            if (handle.StorageId < 0 || handle.StorageId >= MotionTypeCount) return false;
+            CheckTypeId(handle);
             return list[handle.StorageId].TryCancel(handle);
         }
 

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionManager.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionManager.cs
@@ -37,14 +37,34 @@ namespace LitMotion
         public static void Complete(MotionHandle handle)
         {
             CheckTypeId(handle);
-            list[handle.StorageId].Complete(handle);
+            if (!list[handle.StorageId].TryComplete(handle))
+            {
+                Error.MotionNotExists();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryComplete(MotionHandle handle)
+        {
+            if (handle.StorageId < 0 || handle.StorageId >= MotionTypeCount) return false;
+            return list[handle.StorageId].TryComplete(handle);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Cancel(MotionHandle handle)
         {
             CheckTypeId(handle);
-            list[handle.StorageId].Cancel(handle);
+            if (!list[handle.StorageId].TryCancel(handle))
+            {
+                Error.MotionNotExists();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryCancel(MotionHandle handle)
+        {
+            if (handle.StorageId < 0 || handle.StorageId >= MotionTypeCount) return false;
+            return list[handle.StorageId].TryCancel(handle);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionStorage.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionStorage.cs
@@ -102,7 +102,6 @@ namespace LitMotion
                 }
             }
 
-            managedDataRef.IsCallbackRunning = false;
             managedDataRef.CancelOnError = buffer.CancelOnError;
             managedDataRef.UpdateAction = buffer.UpdateAction;
             managedDataRef.UpdateActionPtr = buffer.UpdateActionPtr;

--- a/src/LitMotion/Assets/LitMotion/Runtime/MotionHandleExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/MotionHandleExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using UnityEngine;
@@ -16,6 +17,7 @@ namespace LitMotion
         /// </summary>
         /// <param name="handle">This motion handle</param>
         /// <returns>True if motion is active, otherwise false.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsActive(this MotionHandle handle)
         {
             return MotionManager.IsActive(handle);
@@ -25,6 +27,7 @@ namespace LitMotion
         /// Complete motion.
         /// </summary>
         /// <param name="handle">This motion handle</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Complete(this MotionHandle handle)
         {
             MotionManager.Complete(handle);
@@ -35,6 +38,7 @@ namespace LitMotion
         /// </summary>
         /// <param name="handle">This motion handle</param>
         /// <returns>Returns true if the operation was successful.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryComplete(this MotionHandle handle)
         {
             return MotionManager.TryComplete(handle);
@@ -44,6 +48,7 @@ namespace LitMotion
         /// Cancel motion.
         /// </summary>
         /// <param name="handle">This motion handle</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Cancel(this MotionHandle handle)
         {
             MotionManager.Cancel(handle);
@@ -54,6 +59,7 @@ namespace LitMotion
         /// </summary>
         /// <param name="handle">This motion handle</param>
         /// <returns>Returns true if the operation was successful.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryCancel(this MotionHandle handle)
         {
             return MotionManager.TryCancel(handle);

--- a/src/LitMotion/Assets/LitMotion/Runtime/MotionHandleExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/MotionHandleExtensions.cs
@@ -31,12 +31,32 @@ namespace LitMotion
         }
 
         /// <summary>
+        /// Attempt to complete the motion.
+        /// </summary>
+        /// <param name="handle">This motion handle</param>
+        /// <returns>Returns true if the operation was successful.</returns>
+        public static bool TryComplete(this MotionHandle handle)
+        {
+            return MotionManager.TryComplete(handle);
+        }
+
+        /// <summary>
         /// Cancel motion.
         /// </summary>
         /// <param name="handle">This motion handle</param>
         public static void Cancel(this MotionHandle handle)
         {
             MotionManager.Cancel(handle);
+        }
+
+        /// <summary>
+        /// Attempt to cancel the motion.
+        /// </summary>
+        /// <param name="handle">This motion handle</param>
+        /// <returns>Returns true if the operation was successful.</returns>
+        public static bool TryCancel(this MotionHandle handle)
+        {
+            return MotionManager.TryCancel(handle);
         }
 
         /// <summary>

--- a/src/LitMotion/Assets/LitMotion/Tests/Runtime/CallbackTest.cs
+++ b/src/LitMotion/Assets/LitMotion/Tests/Runtime/CallbackTest.cs
@@ -55,19 +55,20 @@ namespace LitMotion.Tests.Runtime
         [Test]
         public void Test_CompleteOnCallback_Self()
         {
-            LogAssert.Expect(LogType.Exception, "InvalidOperationException: Recursion of Complete call was detected.");
+            LogAssert.Expect(LogType.Exception, "InvalidOperationException: Motion has already been canceled or completed.");
 
             MotionHandle handle = default;
             handle = LMotion.Create(0f, 10f, 1f)
                 .WithOnComplete(() => handle.Complete())
                 .RunWithoutBinding();
+                
             handle.Complete();
         }
 
         [Test]
         public void Test_CompleteOnCallback_CircularReference()
         {
-            LogAssert.Expect(LogType.Exception, "InvalidOperationException: Recursion of Complete call was detected.");
+            LogAssert.Expect(LogType.Exception, "InvalidOperationException: Motion has already been canceled or completed.");
 
             MotionHandle handle1 = default;
             MotionHandle handle2 = default;


### PR DESCRIPTION
`TryCancel()` and `TryComplete()` have been added to `MotionHandle`. This makes it possible to write the following code more concisely.

```cs
// before
if (handle.IsActive())
{
    handle.Cancel();
}

// after
handle.TryCancel();
```

In addition, calling `Complete()` for infinitely looping motions has been changed to throw `InvalidOperationException`. Furthermore, the error message has been improved to make it easier for users to understand.
