### PR TITLE
Add `Time` property and `Preserve()` method to `MotionHandle`

### DIFF
--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/Error.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/Error.cs
@@ -31,6 +31,11 @@ namespace LitMotion
             throw new ArgumentOutOfRangeException("Playback speed must be 0 or greater.");
         }
 
+        public static void TimeMustBeZeroOrGreater()
+        {
+            throw new ArgumentOutOfRangeException("Time must be 0 or greater.");
+        }
+
         public static void MotionNotExists()
         {
             throw new InvalidOperationException("Motion has been destroyed or no longer exists.");

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/Error.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/Error.cs
@@ -26,6 +26,11 @@ namespace LitMotion
             throw new ArgumentNullException(message);
         }
 
+        public static void PlaybackSpeedMustBeZeroOrGreater()
+        {
+            throw new ArgumentOutOfRangeException("Playback speed must be 0 or greater.");
+        }
+
         public static void TimeMustBeZeroOrGreater()
         {
             throw new ArgumentOutOfRangeException("Time must be 0 or greater.");

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/Error.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/Error.cs
@@ -26,11 +26,6 @@ namespace LitMotion
             throw new ArgumentNullException(message);
         }
 
-        public static void PlaybackSpeedMustBeZeroOrGreater()
-        {
-            throw new ArgumentOutOfRangeException("Playback speed must be 0 or greater.");
-        }
-
         public static void TimeMustBeZeroOrGreater()
         {
             throw new ArgumentOutOfRangeException("Time must be 0 or greater.");

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionData.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionData.cs
@@ -10,6 +10,7 @@ namespace LitMotion
         public MotionStatus Status;
         public double Time;
         public float PlaybackSpeed;
+        public bool IsPreserved;
 
         // parameters
         public float Duration;

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionData.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionData.cs
@@ -11,6 +11,7 @@ namespace LitMotion
         public double Time;
         public float PlaybackSpeed;
         public bool IsPreserved;
+        public bool WasStatusChanged;
 
         // parameters
         public float Duration;

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionData.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionData.cs
@@ -6,20 +6,19 @@ namespace LitMotion
     [StructLayout(LayoutKind.Sequential)]
     public struct MotionDataCore
     {
+        // state
         public MotionStatus Status;
-
         public double Time;
         public float PlaybackSpeed;
+
+        // parameters
         public float Duration;
-
         public Ease Ease;
-
 #if LITMOTION_COLLECTIONS_2_0_OR_NEWER
         public NativeAnimationCurve AnimationCurve;
 #else
         public UnsafeAnimationCurve AnimationCurve;
 #endif
-
         public MotionTimeKind TimeKind;
         public float Delay;
         public int Loops;

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionHelper.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionHelper.cs
@@ -15,7 +15,8 @@ namespace LitMotion
         {
             var corePtr = (MotionDataCore*)ptr;
 
-            corePtr->Time = math.max(time, 0.0);
+            corePtr->Time = time;
+            time = math.max(time, 0.0);
 
             double t;
             bool isCompleted;
@@ -39,13 +40,17 @@ namespace LitMotion
                         t = 0f;
                         completedLoops = timeSinceStart < 0f ? -1 : 0;
                     }
-                    clampedCompletedLoops = corePtr->Loops < 0 ? math.max(0, completedLoops) : math.clamp(completedLoops, 0, corePtr->Loops);
+                    clampedCompletedLoops = corePtr->Loops < 0
+                        ? math.max(0, completedLoops)
+                        : math.clamp(completedLoops, 0, corePtr->Loops);
                     isDelayed = timeSinceStart < 0;
                 }
                 else
                 {
                     completedLoops = (int)math.floor(time / corePtr->Delay);
-                    clampedCompletedLoops = corePtr->Loops < 0 ? math.max(0, completedLoops) : math.clamp(completedLoops, 0, corePtr->Loops);
+                    clampedCompletedLoops = corePtr->Loops < 0
+                        ? math.max(0, completedLoops)
+                        : math.clamp(completedLoops, 0, corePtr->Loops);
                     isCompleted = corePtr->Loops >= 0 && clampedCompletedLoops > corePtr->Loops - 1;
                     isDelayed = !isCompleted;
                     t = isCompleted ? 1f : 0f;
@@ -57,7 +62,9 @@ namespace LitMotion
                 {
                     var timeSinceStart = time - corePtr->Delay;
                     completedLoops = (int)math.floor(timeSinceStart / corePtr->Duration);
-                    clampedCompletedLoops = corePtr->Loops < 0 ? math.max(0, completedLoops) : math.clamp(completedLoops, 0, corePtr->Loops);
+                    clampedCompletedLoops = corePtr->Loops < 0
+                        ? math.max(0, completedLoops)
+                        : math.clamp(completedLoops, 0, corePtr->Loops);
                     isCompleted = corePtr->Loops >= 0 && clampedCompletedLoops > corePtr->Loops - 1;
                     isDelayed = timeSinceStart < 0f;
 

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionHelper.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionHelper.cs
@@ -1,0 +1,149 @@
+using Unity.Burst;
+using Unity.Burst.CompilerServices;
+using Unity.Mathematics;
+
+namespace LitMotion
+{
+    [BurstCompile]
+    internal unsafe static class MotionHelper
+    {
+        [BurstCompile]
+        public static void Update<TValue, TOptions, TAdapter>(MotionData<TValue, TOptions>* ptr, double deltaTime, out TValue result)
+            where TValue : unmanaged
+            where TOptions : unmanaged, IMotionOptions
+            where TAdapter : unmanaged, IMotionAdapter<TValue, TOptions>
+        {
+            var corePtr = (MotionDataCore*)ptr;
+
+            corePtr->Time = math.max(corePtr->Time + deltaTime * corePtr->PlaybackSpeed, 0.0);
+            var motionTime = corePtr->Time;
+
+            double t;
+            bool isCompleted;
+            bool isDelayed;
+            int completedLoops;
+            int clampedCompletedLoops;
+
+            if (Hint.Unlikely(corePtr->Duration <= 0f))
+            {
+                if (corePtr->DelayType == DelayType.FirstLoop || corePtr->Delay == 0f)
+                {
+                    var time = motionTime - corePtr->Delay;
+                    isCompleted = corePtr->Loops >= 0 && time > 0f;
+                    if (isCompleted)
+                    {
+                        t = 1f;
+                        completedLoops = corePtr->Loops;
+                    }
+                    else
+                    {
+                        t = 0f;
+                        completedLoops = time < 0f ? -1 : 0;
+                    }
+                    clampedCompletedLoops = corePtr->Loops < 0 ? math.max(0, completedLoops) : math.clamp(completedLoops, 0, corePtr->Loops);
+                    isDelayed = time < 0;
+                }
+                else
+                {
+                    completedLoops = (int)math.floor(motionTime / corePtr->Delay);
+                    clampedCompletedLoops = corePtr->Loops < 0 ? math.max(0, completedLoops) : math.clamp(completedLoops, 0, corePtr->Loops);
+                    isCompleted = corePtr->Loops >= 0 && clampedCompletedLoops > corePtr->Loops - 1;
+                    isDelayed = !isCompleted;
+                    t = isCompleted ? 1f : 0f;
+                }
+            }
+            else
+            {
+                if (corePtr->DelayType == DelayType.FirstLoop)
+                {
+                    var time = motionTime - corePtr->Delay;
+                    completedLoops = (int)math.floor(time / corePtr->Duration);
+                    clampedCompletedLoops = corePtr->Loops < 0 ? math.max(0, completedLoops) : math.clamp(completedLoops, 0, corePtr->Loops);
+                    isCompleted = corePtr->Loops >= 0 && clampedCompletedLoops > corePtr->Loops - 1;
+                    isDelayed = time < 0f;
+
+                    if (isCompleted)
+                    {
+                        t = 1f;
+                    }
+                    else
+                    {
+                        var currentLoopTime = time - corePtr->Duration * clampedCompletedLoops;
+                        t = math.clamp(currentLoopTime / corePtr->Duration, 0f, 1f);
+                    }
+                }
+                else
+                {
+                    var currentLoopTime = math.fmod(motionTime, corePtr->Duration + corePtr->Delay) - corePtr->Delay;
+                    completedLoops = (int)math.floor(motionTime / (corePtr->Duration + corePtr->Delay));
+                    clampedCompletedLoops = corePtr->Loops < 0 ? math.max(0, completedLoops) : math.clamp(completedLoops, 0, corePtr->Loops);
+                    isCompleted = corePtr->Loops >= 0 && clampedCompletedLoops > corePtr->Loops - 1;
+                    isDelayed = currentLoopTime < 0;
+
+                    if (isCompleted)
+                    {
+                        t = 1f;
+                    }
+                    else
+                    {
+                        t = math.clamp(currentLoopTime / corePtr->Duration, 0f, 1f);
+                    }
+                }
+            }
+
+            float progress;
+            switch (corePtr->LoopType)
+            {
+                default:
+                case LoopType.Restart:
+                    progress = GetEasedValue(corePtr, (float)t);
+                    break;
+                case LoopType.Flip:
+                    progress = GetEasedValue(corePtr, (float)t);
+                    if ((clampedCompletedLoops + (int)t) % 2 == 1) progress = 1f - progress;
+                    break;
+                case LoopType.Incremental:
+                    progress = GetEasedValue(corePtr, 1f) * clampedCompletedLoops + GetEasedValue(corePtr, (float)math.fmod(t, 1f));
+                    break;
+                case LoopType.Yoyo:
+                    progress = (clampedCompletedLoops + (int)t) % 2 == 1
+                        ? GetEasedValue(corePtr, (float)(1f - t))
+                        : GetEasedValue(corePtr, (float)t);
+                    break;
+            }
+
+            var totalDuration = corePtr->DelayType == DelayType.FirstLoop
+                ? corePtr->Delay + corePtr->Duration * corePtr->Loops
+                : (corePtr->Delay + corePtr->Duration) * corePtr->Loops;
+
+            if (corePtr->Loops > 0 && motionTime >= totalDuration)
+            {
+                corePtr->Status = MotionStatus.Completed;
+            }
+            else if (isDelayed)
+            {
+                corePtr->Status = MotionStatus.Delayed;
+            }
+            else
+            {
+                corePtr->Status = MotionStatus.Playing;
+            }
+
+            var context = new MotionEvaluationContext()
+            {
+                Progress = progress
+            };
+
+            result = default(TAdapter).Evaluate(ref ptr->StartValue, ref ptr->EndValue, ref ptr->Options, context);
+        }
+
+        static float GetEasedValue(MotionDataCore* data, float value)
+        {
+            return data->Ease switch
+            {
+                Ease.CustomAnimationCurve => data->AnimationCurve.Evaluate(value),
+                _ => EaseUtility.Evaluate(value, data->Ease)
+            };
+        }
+    }
+}

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionHelper.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionHelper.cs
@@ -16,7 +16,6 @@ namespace LitMotion
             var corePtr = (MotionDataCore*)ptr;
 
             corePtr->Time = math.max(time, 0.0);
-            var motionTime = corePtr->Time;
 
             double t;
             bool isCompleted;
@@ -28,7 +27,7 @@ namespace LitMotion
             {
                 if (corePtr->DelayType == DelayType.FirstLoop || corePtr->Delay == 0f)
                 {
-                    var timeSinceStart = motionTime - corePtr->Delay;
+                    var timeSinceStart = time - corePtr->Delay;
                     isCompleted = corePtr->Loops >= 0 && timeSinceStart > 0f;
                     if (isCompleted)
                     {
@@ -45,7 +44,7 @@ namespace LitMotion
                 }
                 else
                 {
-                    completedLoops = (int)math.floor(motionTime / corePtr->Delay);
+                    completedLoops = (int)math.floor(time / corePtr->Delay);
                     clampedCompletedLoops = corePtr->Loops < 0 ? math.max(0, completedLoops) : math.clamp(completedLoops, 0, corePtr->Loops);
                     isCompleted = corePtr->Loops >= 0 && clampedCompletedLoops > corePtr->Loops - 1;
                     isDelayed = !isCompleted;
@@ -56,7 +55,7 @@ namespace LitMotion
             {
                 if (corePtr->DelayType == DelayType.FirstLoop)
                 {
-                    var timeSinceStart = motionTime - corePtr->Delay;
+                    var timeSinceStart = time - corePtr->Delay;
                     completedLoops = (int)math.floor(timeSinceStart / corePtr->Duration);
                     clampedCompletedLoops = corePtr->Loops < 0 ? math.max(0, completedLoops) : math.clamp(completedLoops, 0, corePtr->Loops);
                     isCompleted = corePtr->Loops >= 0 && clampedCompletedLoops > corePtr->Loops - 1;
@@ -74,9 +73,11 @@ namespace LitMotion
                 }
                 else
                 {
-                    var currentLoopTime = math.fmod(motionTime, corePtr->Duration + corePtr->Delay) - corePtr->Delay;
-                    completedLoops = (int)math.floor(motionTime / (corePtr->Duration + corePtr->Delay));
-                    clampedCompletedLoops = corePtr->Loops < 0 ? math.max(0, completedLoops) : math.clamp(completedLoops, 0, corePtr->Loops);
+                    var currentLoopTime = math.fmod(time, corePtr->Duration + corePtr->Delay) - corePtr->Delay;
+                    completedLoops = (int)math.floor(time / (corePtr->Duration + corePtr->Delay));
+                    clampedCompletedLoops = corePtr->Loops < 0
+                        ? math.max(0, completedLoops)
+                        : math.clamp(completedLoops, 0, corePtr->Loops);
                     isCompleted = corePtr->Loops >= 0 && clampedCompletedLoops > corePtr->Loops - 1;
                     isDelayed = currentLoopTime < 0;
 
@@ -116,7 +117,7 @@ namespace LitMotion
                 ? corePtr->Delay + corePtr->Duration * corePtr->Loops
                 : (corePtr->Delay + corePtr->Duration) * corePtr->Loops;
 
-            if (corePtr->Loops > 0 && motionTime >= totalDuration)
+            if (isCompleted)
             {
                 corePtr->Status = MotionStatus.Completed;
             }

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionHelper.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionHelper.cs
@@ -14,6 +14,10 @@ namespace LitMotion
             where TAdapter : unmanaged, IMotionAdapter<TValue, TOptions>
         {
             var corePtr = (MotionDataCore*)ptr;
+            var prevStatus = corePtr->Status;
+
+            // reset flag(s)
+            corePtr->WasStatusChanged = false;
 
             corePtr->Time = time;
             time = math.max(time, 0.0);
@@ -136,6 +140,8 @@ namespace LitMotion
             {
                 corePtr->Status = MotionStatus.Playing;
             }
+
+            corePtr->WasStatusChanged = prevStatus != corePtr->Status;
 
             var context = new MotionEvaluationContext()
             {

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionHelper.cs.meta
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionHelper.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b7b3337d974654c029ff5bfa7e15049c

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionManager.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionManager.cs
@@ -68,6 +68,13 @@ namespace LitMotion
             return list[handle.StorageId].IsActive(handle);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void SetTime(MotionHandle handle, double time)
+        {
+            CheckTypeId(handle);
+            list[handle.StorageId].SetTime(handle, time);
+        }
+
         // For MotionTracker
         public static (Type ValueType, Type OptionsType, Type AdapterType) GetMotionType(MotionHandle handle)
         {

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionStorage.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionStorage.cs
@@ -368,10 +368,7 @@ namespace LitMotion
                 var version = slot.Version;
                 if (version <= 0 || version != handle.Version) Error.MotionNotExists();
 
-                var prevTime = dataPtr->Core.Time;
-                var deltaTime = time - prevTime;
-
-                MotionHelper.Update<TValue, TOptions, TAdapter>(dataPtr + denseIndex, deltaTime, out var result);
+                MotionHelper.SetTime<TValue, TOptions, TAdapter>(dataPtr + denseIndex, time, out var result);
 
                 try
                 {

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionStorage.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionStorage.cs
@@ -310,8 +310,7 @@ namespace LitMotion
 
             ref var managedData = ref managedDataArray[denseIndex];
 
-            // To avoid duplication of Complete processing, it is treated as canceled internally.
-            unmanagedData.Core.Status = MotionStatus.Canceled;
+            unmanagedData.Core.Status = MotionStatus.Completed;
 
             var endProgress = unmanagedData.Core.LoopType switch
             {

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionStorage.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionStorage.cs
@@ -72,9 +72,10 @@ namespace LitMotion
             ref var dataRef = ref unmanagedDataArray[tail];
             ref var managedDataRef = ref managedDataArray[tail];
 
+            dataRef.Core.Status = MotionStatus.Scheduled;
             dataRef.Core.Time = 0;
             dataRef.Core.PlaybackSpeed = 1f;
-            dataRef.Core.Status = MotionStatus.Scheduled;
+            dataRef.Core.IsPreserved = false;
 
             dataRef.Core.Duration = buffer.Duration;
             dataRef.Core.Delay = buffer.Delay;

--- a/src/LitMotion/Assets/LitMotion/Runtime/MotionHandle.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/MotionHandle.cs
@@ -49,6 +49,7 @@ namespace LitMotion
             }
             set
             {
+                if (value < 0f) Error.PlaybackSpeedMustBeZeroOrGreater();
                 MotionManager.GetDataRef(this).PlaybackSpeed = value;
             }
         }

--- a/src/LitMotion/Assets/LitMotion/Runtime/MotionHandle.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/MotionHandle.cs
@@ -23,6 +23,22 @@ namespace LitMotion
         public int Version;
 
         /// <summary>
+        /// Motion time
+        /// </summary>
+        public readonly double Time
+        {
+            get
+            {
+                return MotionManager.GetDataRef(this).Time;
+            }
+            set
+            {
+                if (value < 0f) Error.TimeMustBeZeroOrGreater();
+                MotionManager.SetTime(this, value);
+            }
+        }
+
+        /// <summary>
         /// Motion playback speed.
         /// </summary>
         public readonly float PlaybackSpeed

--- a/src/LitMotion/Assets/LitMotion/Runtime/MotionHandle.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/MotionHandle.cs
@@ -49,7 +49,6 @@ namespace LitMotion
             }
             set
             {
-                if (value < 0f) Error.PlaybackSpeedMustBeZeroOrGreater();
                 MotionManager.GetDataRef(this).PlaybackSpeed = value;
             }
         }

--- a/src/LitMotion/Assets/LitMotion/Runtime/MotionHandleExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/MotionHandleExtensions.cs
@@ -23,6 +23,12 @@ namespace LitMotion
             return MotionManager.IsActive(handle);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Preserve(this MotionHandle handle)
+        {
+            MotionManager.GetDataRef(handle).IsPreserved = true;
+        }
+
         /// <summary>
         /// Complete motion.
         /// </summary>

--- a/src/LitMotion/Assets/LitMotion/Runtime/MotionUpdateJob.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/MotionUpdateJob.cs
@@ -42,7 +42,9 @@ namespace LitMotion
                     _ => default
                 };
 
-                MotionHelper.Update<TValue, TOptions, TAdapter>(ptr, deltaTime, out var result);
+                var time = corePtr->Time + deltaTime * corePtr->PlaybackSpeed;
+
+                MotionHelper.SetTime<TValue, TOptions, TAdapter>(ptr, time, out var result);
 
                 Output[index] = result;
             }

--- a/src/LitMotion/Assets/LitMotion/Runtime/MotionUpdateJob.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/MotionUpdateJob.cs
@@ -48,7 +48,7 @@ namespace LitMotion
 
                 Output[index] = result;
             }
-            else if (corePtr->Status is MotionStatus.Completed or MotionStatus.Canceled)
+            else if ((!corePtr->IsPreserved && corePtr->Status is MotionStatus.Completed) || corePtr->Status is MotionStatus.Canceled)
             {
                 CompletedIndexList.AddNoResize(index);
                 corePtr->Status = MotionStatus.Disposed;

--- a/src/LitMotion/Assets/LitMotion/Runtime/MotionUpdateJob.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/MotionUpdateJob.cs
@@ -42,141 +42,15 @@ namespace LitMotion
                     _ => default
                 };
 
-                corePtr->Time = math.max(corePtr->Time + deltaTime * corePtr->PlaybackSpeed, 0.0);
-                var motionTime = corePtr->Time;
+                MotionHelper.Update<TValue, TOptions, TAdapter>(ptr, deltaTime, out var result);
 
-                double t;
-                bool isCompleted;
-                bool isDelayed;
-                int completedLoops;
-                int clampedCompletedLoops;
-
-                if (Hint.Unlikely(corePtr->Duration <= 0f))
-                {
-                    if (corePtr->DelayType == DelayType.FirstLoop || corePtr->Delay == 0f)
-                    {
-                        var time = motionTime - corePtr->Delay;
-                        isCompleted = corePtr->Loops >= 0 && time > 0f;
-                        if (isCompleted)
-                        {
-                            t = 1f;
-                            completedLoops = corePtr->Loops;
-                        }
-                        else
-                        {
-                            t = 0f;
-                            completedLoops = time < 0f ? -1 : 0;
-                        }
-                        clampedCompletedLoops = corePtr->Loops < 0 ? math.max(0, completedLoops) : math.clamp(completedLoops, 0, corePtr->Loops);
-                        isDelayed = time < 0;
-                    }
-                    else
-                    {
-                        completedLoops = (int)math.floor(motionTime / corePtr->Delay);
-                        clampedCompletedLoops = corePtr->Loops < 0 ? math.max(0, completedLoops) : math.clamp(completedLoops, 0, corePtr->Loops);
-                        isCompleted = corePtr->Loops >= 0 && clampedCompletedLoops > corePtr->Loops - 1;
-                        isDelayed = !isCompleted;
-                        t = isCompleted ? 1f : 0f;
-                    }
-                }
-                else
-                {
-                    if (corePtr->DelayType == DelayType.FirstLoop)
-                    {
-                        var time = motionTime - corePtr->Delay;
-                        completedLoops = (int)math.floor(time / corePtr->Duration);
-                        clampedCompletedLoops = corePtr->Loops < 0 ? math.max(0, completedLoops) : math.clamp(completedLoops, 0, corePtr->Loops);
-                        isCompleted = corePtr->Loops >= 0 && clampedCompletedLoops > corePtr->Loops - 1;
-                        isDelayed = time < 0f;
-
-                        if (isCompleted)
-                        {
-                            t = 1f;
-                        }
-                        else
-                        {
-                            var currentLoopTime = time - corePtr->Duration * clampedCompletedLoops;
-                            t = math.clamp(currentLoopTime / corePtr->Duration, 0f, 1f);
-                        }
-                    }
-                    else
-                    {
-                        var currentLoopTime = math.fmod(motionTime, corePtr->Duration + corePtr->Delay) - corePtr->Delay;
-                        completedLoops = (int)math.floor(motionTime / (corePtr->Duration + corePtr->Delay));
-                        clampedCompletedLoops = corePtr->Loops < 0 ? math.max(0, completedLoops) : math.clamp(completedLoops, 0, corePtr->Loops);
-                        isCompleted = corePtr->Loops >= 0 && clampedCompletedLoops > corePtr->Loops - 1;
-                        isDelayed = currentLoopTime < 0;
-
-                        if (isCompleted)
-                        {
-                            t = 1f;
-                        }
-                        else
-                        {
-                            t = math.clamp(currentLoopTime / corePtr->Duration, 0f, 1f);
-                        }
-                    }
-                }
-
-                float progress;
-                switch (corePtr->LoopType)
-                {
-                    default:
-                    case LoopType.Restart:
-                        progress = GetEasedValue(corePtr, (float)t);
-                        break;
-                    case LoopType.Flip:
-                        progress = GetEasedValue(corePtr, (float)t);
-                        if ((clampedCompletedLoops + (int)t) % 2 == 1) progress = 1f - progress;
-                        break;
-                    case LoopType.Incremental:
-                        progress = GetEasedValue(corePtr, 1f) * clampedCompletedLoops + GetEasedValue(corePtr, (float)math.fmod(t, 1f));
-                        break;
-                    case LoopType.Yoyo:
-                        progress = (clampedCompletedLoops + (int)t) % 2 == 1
-                            ? GetEasedValue(corePtr, (float)(1f - t))
-                            : GetEasedValue(corePtr, (float)t);
-                        break;
-                }
-
-                var totalDuration = corePtr->DelayType == DelayType.FirstLoop
-                    ? corePtr->Delay + corePtr->Duration * corePtr->Loops
-                    : (corePtr->Delay + corePtr->Duration) * corePtr->Loops;
-
-                if (corePtr->Loops > 0 && motionTime >= totalDuration)
-                {
-                    corePtr->Status = MotionStatus.Completed;
-                }
-                else if (isDelayed)
-                {
-                    corePtr->Status = MotionStatus.Delayed;
-                }
-                else
-                {
-                    corePtr->Status = MotionStatus.Playing;
-                }
-
-                var context = new MotionEvaluationContext()
-                {
-                    Progress = progress
-                };
-
-                Output[index] = default(TAdapter).Evaluate(ref ptr->StartValue, ref ptr->EndValue, ref ptr->Options, context);
+                Output[index] = result;
             }
             else if (corePtr->Status is MotionStatus.Completed or MotionStatus.Canceled)
             {
                 CompletedIndexList.AddNoResize(index);
                 corePtr->Status = MotionStatus.Disposed;
             }
-        }
-
-        static float GetEasedValue(MotionDataCore* data, float value)
-        {
-            return data->Ease switch
-            {
-                Ease.CustomAnimationCurve => data->AnimationCurve.Evaluate(value),
-                _ => EaseUtility.Evaluate(value, data->Ease)
-            };
         }
     }
 }

--- a/src/LitMotion/Assets/LitMotion/Runtime/MotionUpdateJob.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/MotionUpdateJob.cs
@@ -32,7 +32,8 @@ namespace LitMotion
             var ptr = DataPtr + index;
             var corePtr = (MotionDataCore*)ptr;
 
-            if (Hint.Likely(corePtr->Status is MotionStatus.Scheduled or MotionStatus.Delayed or MotionStatus.Playing))
+            if (Hint.Likely(corePtr->Status is MotionStatus.Scheduled or MotionStatus.Delayed or MotionStatus.Playing) || 
+                Hint.Unlikely(corePtr->IsPreserved && corePtr->Status is MotionStatus.Completed))
             {
                 var deltaTime = corePtr->TimeKind switch
                 {

--- a/src/LitMotion/Assets/LitMotion/Tests/Runtime/MotionHandleTest.cs
+++ b/src/LitMotion/Assets/LitMotion/Tests/Runtime/MotionHandleTest.cs
@@ -26,6 +26,28 @@ namespace LitMotion.Tests.Runtime
         }
 
         [UnityTest]
+        public IEnumerator Test_TryCancel()
+        {
+            var value = 0f;
+            var endValue = 10f;
+            var handle = LMotion.Create(0f, endValue, 2f)
+                .Bind(x =>
+                {
+                    value = x;
+                    Debug.Log(x);
+                });
+            yield return new WaitForSeconds(1f);
+            var tryResult = handle.TryCancel();
+            Assert.IsTrue(tryResult);
+            yield return new WaitForSeconds(1f);
+            Assert.IsTrue(value < endValue);
+            Assert.IsTrue(!handle.IsActive());
+
+            tryResult = handle.TryCancel();
+            Assert.IsFalse(tryResult);
+        }
+
+        [UnityTest]
         public IEnumerator Test_Complete()
         {
             var value = 0f;
@@ -40,6 +62,27 @@ namespace LitMotion.Tests.Runtime
             handle.Complete();
             Assert.AreApproximatelyEqual(value, endValue);
             Assert.IsTrue(!handle.IsActive());
+        }
+
+        [UnityTest]
+        public IEnumerator Test_TryComplete()
+        {
+            var value = 0f;
+            var endValue = 10f;
+            var handle = LMotion.Create(0f, endValue, 2f)
+                .Bind(x =>
+                {
+                    value = x;
+                    Debug.Log(x);
+                });
+            yield return new WaitForSeconds(1f);
+            var tryResult = handle.TryComplete();
+            Assert.IsTrue(tryResult);
+            Assert.AreApproximatelyEqual(value, endValue);
+            Assert.IsTrue(!handle.IsActive());
+
+            tryResult = handle.TryComplete();
+            Assert.IsFalse(tryResult);
         }
 
         [UnityTest]
@@ -73,9 +116,9 @@ namespace LitMotion.Tests.Runtime
                     Debug.Log(x);
                 });
             yield return new WaitForSeconds(1f);
-            handle.Complete();
+            handle.TryComplete();
             Assert.IsTrue(handle.IsActive());
-            handle.Cancel();
+            handle.TryCancel();
             Assert.IsTrue(!handle.IsActive());
         }
 

--- a/src/LitMotion/Assets/LitMotion/Tests/Runtime/PlaybackSpeedTest.cs
+++ b/src/LitMotion/Assets/LitMotion/Tests/Runtime/PlaybackSpeedTest.cs
@@ -51,16 +51,5 @@ namespace LitMotion.Tests.Runtime
             yield return handle.ToYieldInteraction();
             Assert.That(Time.time - time, Is.EqualTo(0.5f).Using(new FloatEqualityComparer(0.05f)));
         }
-
-        [Test]
-        public void Test_PlaybackSpeed_Minus()
-        {
-            var handle = LMotion.Create(0f, 10f, 1f).RunWithoutBinding();
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
-            {
-                handle.PlaybackSpeed = -1f;
-            });
-        }
-
     }
 }


### PR DESCRIPTION
This PR adds a `Time` property to the `MotionHandle`, which allows you to manually control the playback of individual motions.

It also adds a `Preserve()` method to the `MotionHandle`, so that it won't be automatically destroyed after the motion is complete.

#### Example

```cs
public class Example : MonoBehaviour
{
    [SerializeField] Transform target;
    [SerializeField] Slider slider;

    MotionHandle handle;

    void Start()
    {
        handle = LMotion.Create(-5f, 5f, 1f)
            .WithEase(Ease.OutQuad)
            .BindToPositionX(target)
            .AddTo(target);

        handle.Preserve();
    }

    void Update()
    {
        handle.Time = slider.value;
    }
}
```