### PR TITLE
Rename `ToYieldInteraction()` -> `ToYieldInstruction()`

### DIFF
--- a/src/LitMotion/Assets/LitMotion/Runtime/MotionHandleExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/MotionHandleExtensions.cs
@@ -169,7 +169,7 @@ namespace LitMotion
         /// </summary>
         /// <param name="handle">This motion handle</param>
         /// <returns></returns>
-        public static IEnumerator ToYieldInteraction(this MotionHandle handle)
+        public static IEnumerator ToYieldInstruction(this MotionHandle handle)
         {
             while (handle.IsActive())
             {

--- a/src/LitMotion/Assets/LitMotion/Tests/Runtime/CallbackTest.cs
+++ b/src/LitMotion/Assets/LitMotion/Tests/Runtime/CallbackTest.cs
@@ -61,7 +61,7 @@ namespace LitMotion.Tests.Runtime
             handle = LMotion.Create(0f, 10f, 1f)
                 .WithOnComplete(() => handle.Complete())
                 .RunWithoutBinding();
-                
+
             handle.Complete();
         }
 
@@ -89,7 +89,7 @@ namespace LitMotion.Tests.Runtime
             LMotion.Create(0f, 10f, 0.5f)
                 .WithOnComplete(() => otherHandle.Complete())
                 .RunWithoutBinding();
-            yield return otherHandle.ToYieldInteraction();
+            yield return otherHandle.ToYieldInstruction();
         }
 
         [UnityTest]
@@ -99,7 +99,7 @@ namespace LitMotion.Tests.Runtime
             yield return LMotion.Create(0f, 10f, 0.5f)
                 .WithOnComplete(() => throw new Exception("Test"))
                 .RunWithoutBinding()
-                .ToYieldInteraction();
+                .ToYieldInstruction();
         }
 
         [Test]
@@ -135,7 +135,7 @@ namespace LitMotion.Tests.Runtime
             yield return LMotion.Create(0f, 10f, 0.5f)
                 .WithOnComplete(() => throw new Exception("Test"))
                 .RunWithoutBinding()
-                .ToYieldInteraction();
+                .ToYieldInstruction();
             MotionDispatcher.RegisterUnhandledExceptionHandler(defaultHandler);
         }
     }

--- a/src/LitMotion/Assets/LitMotion/Tests/Runtime/CoroutineTest.cs
+++ b/src/LitMotion/Assets/LitMotion/Tests/Runtime/CoroutineTest.cs
@@ -11,7 +11,7 @@ namespace LitMotion.Tests.Runtime
         {
             yield return LMotion.Create(0f, 10f, 3f)
                 .BindToUnityLogger()
-                .ToYieldInteraction();
+                .ToYieldInstruction();
         }
     }
 }

--- a/src/LitMotion/Assets/LitMotion/Tests/Runtime/DelayTest.cs
+++ b/src/LitMotion/Assets/LitMotion/Tests/Runtime/DelayTest.cs
@@ -15,7 +15,7 @@ namespace LitMotion.Tests.Runtime
             yield return LMotion.Create(0f, 1f, 0.5f)
                 .WithDelay(0.5f)
                 .BindToUnityLogger()
-                .ToYieldInteraction();
+                .ToYieldInstruction();
             Assert.That(Time.timeAsDouble - t, Is.GreaterThan(0.95).And.LessThan(1.1));
         }
 
@@ -26,7 +26,7 @@ namespace LitMotion.Tests.Runtime
             yield return LMotion.Create(0f, 1f, 0f)
                 .WithDelay(1f)
                 .BindToUnityLogger()
-                .ToYieldInteraction();
+                .ToYieldInstruction();
             Assert.That(Time.timeAsDouble - t, Is.GreaterThan(0.95).And.LessThan(1.1));
         }
 
@@ -38,7 +38,7 @@ namespace LitMotion.Tests.Runtime
                 .WithLoops(2)
                 .WithDelay(0.5f, DelayType.EveryLoop)
                 .BindToUnityLogger()
-                .ToYieldInteraction();
+                .ToYieldInstruction();
             Assert.That(Time.timeAsDouble - t, Is.GreaterThan(1.95).And.LessThan(2.1));
         }
 
@@ -50,7 +50,7 @@ namespace LitMotion.Tests.Runtime
                 .WithLoops(3)
                 .WithDelay(0.5f, DelayType.EveryLoop)
                 .BindToUnityLogger()
-                .ToYieldInteraction();
+                .ToYieldInstruction();
             Assert.That(Time.timeAsDouble - t, Is.GreaterThan(1.45).And.LessThan(1.6));
         }
 

--- a/src/LitMotion/Assets/LitMotion/Tests/Runtime/EaseTest.cs
+++ b/src/LitMotion/Assets/LitMotion/Tests/Runtime/EaseTest.cs
@@ -16,7 +16,7 @@ namespace LitMotion.Tests.Runtime
                 yield return LMotion.Create(0f, 10f, 0.2f)
                     .WithEase(curve)
                     .RunWithoutBinding()
-                    .ToYieldInteraction();
+                    .ToYieldInstruction();
             }
         }
     }

--- a/src/LitMotion/Assets/LitMotion/Tests/Runtime/PlaybackSpeedTest.cs
+++ b/src/LitMotion/Assets/LitMotion/Tests/Runtime/PlaybackSpeedTest.cs
@@ -19,7 +19,7 @@ namespace LitMotion.Tests.Runtime
             handle.PlaybackSpeed = 0.5f;
 
             var time = Time.timeAsDouble;
-            yield return handle.ToYieldInteraction();
+            yield return handle.ToYieldInstruction();
             Assert.That(Time.timeAsDouble - time, Is.GreaterThan(2.0));
         }
 
@@ -45,10 +45,10 @@ namespace LitMotion.Tests.Runtime
             var value = 0f;
             var handle = LMotion.Create(0f, endValue, 1f)
                 .Bind(x => value = x);
-            
+
             handle.PlaybackSpeed = 2f;
             var time = Time.time;
-            yield return handle.ToYieldInteraction();
+            yield return handle.ToYieldInstruction();
             Assert.That(Time.time - time, Is.EqualTo(0.5f).Using(new FloatEqualityComparer(0.05f)));
         }
     }

--- a/src/LitMotion/Assets/LitMotion/Tests/Runtime/SchedulerTest.cs
+++ b/src/LitMotion/Assets/LitMotion/Tests/Runtime/SchedulerTest.cs
@@ -21,7 +21,7 @@ namespace LitMotion.Tests.Runtime
             yield return LMotion.Create(0f, 10f, Duration)
                 .WithScheduler(MotionScheduler.Initialization)
                 .RunWithoutBinding()
-                .ToYieldInteraction();
+                .ToYieldInstruction();
         }
 
         [UnityTest]
@@ -31,7 +31,7 @@ namespace LitMotion.Tests.Runtime
             yield return LMotion.Create(0f, 10f, Duration)
                 .WithScheduler(MotionScheduler.InitializationIgnoreTimeScale)
                 .RunWithoutBinding()
-                .ToYieldInteraction();
+                .ToYieldInstruction();
         }
 
         [UnityTest]
@@ -41,7 +41,7 @@ namespace LitMotion.Tests.Runtime
             yield return LMotion.Create(0f, 10f, Duration)
                 .WithScheduler(MotionScheduler.InitializationRealtime)
                 .RunWithoutBinding()
-                .ToYieldInteraction();
+                .ToYieldInstruction();
         }
 
         [UnityTest]
@@ -50,7 +50,7 @@ namespace LitMotion.Tests.Runtime
             yield return LMotion.Create(0f, 10f, Duration)
                 .WithScheduler(MotionScheduler.EarlyUpdate)
                 .RunWithoutBinding()
-                .ToYieldInteraction();
+                .ToYieldInstruction();
         }
 
         [UnityTest]
@@ -60,7 +60,7 @@ namespace LitMotion.Tests.Runtime
             yield return LMotion.Create(0f, 10f, Duration)
                 .WithScheduler(MotionScheduler.EarlyUpdateIgnoreTimeScale)
                 .RunWithoutBinding()
-                .ToYieldInteraction();
+                .ToYieldInstruction();
         }
 
         [UnityTest]
@@ -70,7 +70,7 @@ namespace LitMotion.Tests.Runtime
             yield return LMotion.Create(0f, 10f, Duration)
                 .WithScheduler(MotionScheduler.EarlyUpdateRealtime)
                 .RunWithoutBinding()
-                .ToYieldInteraction();
+                .ToYieldInstruction();
         }
 
         [UnityTest]
@@ -82,7 +82,7 @@ namespace LitMotion.Tests.Runtime
                 {
                     Assert.IsTrue(Time.inFixedTimeStep);
                 })
-                .ToYieldInteraction();
+                .ToYieldInstruction();
         }
 
         [UnityTest]
@@ -91,7 +91,7 @@ namespace LitMotion.Tests.Runtime
             yield return LMotion.Create(0f, 10f, Duration)
                 .WithScheduler(MotionScheduler.Update)
                 .RunWithoutBinding()
-                .ToYieldInteraction();
+                .ToYieldInstruction();
         }
 
         [UnityTest]
@@ -102,7 +102,7 @@ namespace LitMotion.Tests.Runtime
             yield return LMotion.Create(0f, 10f, Duration)
                 .WithScheduler(MotionScheduler.Update)
                 .RunWithoutBinding()
-                .ToYieldInteraction();
+                .ToYieldInstruction();
             Assert.That(Time.unscaledTimeAsDouble - t, Is.GreaterThan(Duration * 2f));
         }
 
@@ -113,7 +113,7 @@ namespace LitMotion.Tests.Runtime
             yield return LMotion.Create(0f, 10f, Duration)
                 .WithScheduler(MotionScheduler.UpdateIgnoreTimeScale)
                 .RunWithoutBinding()
-                .ToYieldInteraction();
+                .ToYieldInstruction();
         }
 
         [UnityTest]
@@ -123,7 +123,7 @@ namespace LitMotion.Tests.Runtime
             yield return LMotion.Create(0f, 10f, Duration)
                 .WithScheduler(MotionScheduler.UpdateRealtime)
                 .RunWithoutBinding()
-                .ToYieldInteraction();
+                .ToYieldInstruction();
         }
 
         [UnityTest]
@@ -132,7 +132,7 @@ namespace LitMotion.Tests.Runtime
             yield return LMotion.Create(0f, 10f, Duration)
                 .WithScheduler(MotionScheduler.PreLateUpdate)
                 .RunWithoutBinding()
-                .ToYieldInteraction();
+                .ToYieldInstruction();
         }
 
         [UnityTest]
@@ -142,7 +142,7 @@ namespace LitMotion.Tests.Runtime
             yield return LMotion.Create(0f, 10f, Duration)
                 .WithScheduler(MotionScheduler.PreLateUpdateIgnoreTimeScale)
                 .RunWithoutBinding()
-                .ToYieldInteraction();
+                .ToYieldInstruction();
         }
 
         [UnityTest]
@@ -152,7 +152,7 @@ namespace LitMotion.Tests.Runtime
             yield return LMotion.Create(0f, 10f, Duration)
                 .WithScheduler(MotionScheduler.PreLateUpdateRealtime)
                 .RunWithoutBinding()
-                .ToYieldInteraction();
+                .ToYieldInstruction();
         }
 
         [UnityTest]
@@ -161,7 +161,7 @@ namespace LitMotion.Tests.Runtime
             yield return LMotion.Create(0f, 10f, Duration)
                 .WithScheduler(MotionScheduler.PostLateUpdate)
                 .RunWithoutBinding()
-                .ToYieldInteraction();
+                .ToYieldInstruction();
         }
 
         [UnityTest]
@@ -171,7 +171,7 @@ namespace LitMotion.Tests.Runtime
             yield return LMotion.Create(0f, 10f, Duration)
                 .WithScheduler(MotionScheduler.PostLateUpdateIgnoreTimeScale)
                 .RunWithoutBinding()
-                .ToYieldInteraction();
+                .ToYieldInstruction();
         }
 
         [UnityTest]
@@ -181,7 +181,7 @@ namespace LitMotion.Tests.Runtime
             yield return LMotion.Create(0f, 10f, Duration)
                 .WithScheduler(MotionScheduler.PostLateUpdateRealtime)
                 .RunWithoutBinding()
-                .ToYieldInteraction();
+                .ToYieldInstruction();
         }
 
         [UnityTest]
@@ -190,7 +190,7 @@ namespace LitMotion.Tests.Runtime
             yield return LMotion.Create(0f, 10f, Duration)
                 .WithScheduler(MotionScheduler.TimeUpdate)
                 .RunWithoutBinding()
-                .ToYieldInteraction();
+                .ToYieldInstruction();
         }
 
         [UnityTest]
@@ -200,7 +200,7 @@ namespace LitMotion.Tests.Runtime
             yield return LMotion.Create(0f, 10f, Duration)
                 .WithScheduler(MotionScheduler.TimeUpdateIgnoreTimeScale)
                 .RunWithoutBinding()
-                .ToYieldInteraction();
+                .ToYieldInstruction();
         }
 
         [UnityTest]
@@ -210,7 +210,7 @@ namespace LitMotion.Tests.Runtime
             yield return LMotion.Create(0f, 10f, Duration)
                 .WithScheduler(MotionScheduler.TimeUpdateRealtime)
                 .RunWithoutBinding()
-                .ToYieldInteraction();
+                .ToYieldInstruction();
         }
     }
 }

--- a/src/LitMotion/Assets/LitMotion/Tests/Runtime/TransformTest.cs
+++ b/src/LitMotion/Assets/LitMotion/Tests/Runtime/TransformTest.cs
@@ -28,7 +28,7 @@ namespace LitMotion.Tests.Runtime
         public IEnumerator Test_BindToPosition()
         {
             var endValue = Vector3.one;
-            yield return LMotion.Create(Vector3.zero, endValue, Duration).BindToPosition(target).ToYieldInteraction();
+            yield return LMotion.Create(Vector3.zero, endValue, Duration).BindToPosition(target).ToYieldInstruction();
             Assert.That(target.position, Is.EqualTo(endValue).Using(Vector3EqualityComparer.Instance));
         }
 
@@ -36,7 +36,7 @@ namespace LitMotion.Tests.Runtime
         public IEnumerator Test_BindToPositionX()
         {
             var endValue = 10f;
-            yield return LMotion.Create(1f, endValue, Duration).BindToPositionX(target).ToYieldInteraction();
+            yield return LMotion.Create(1f, endValue, Duration).BindToPositionX(target).ToYieldInstruction();
             Assert.That(target.position.x, Is.EqualTo(endValue).Using(FloatEqualityComparer.Instance));
         }
 
@@ -44,7 +44,7 @@ namespace LitMotion.Tests.Runtime
         public IEnumerator Test_BindToPositionY()
         {
             var endValue = 10f;
-            yield return LMotion.Create(1f, endValue, Duration).BindToPositionY(target).ToYieldInteraction();
+            yield return LMotion.Create(1f, endValue, Duration).BindToPositionY(target).ToYieldInstruction();
             Assert.That(target.position.y, Is.EqualTo(endValue).Using(FloatEqualityComparer.Instance));
         }
 
@@ -52,31 +52,31 @@ namespace LitMotion.Tests.Runtime
         public IEnumerator Test_BindToPositionZ()
         {
             var endValue = 10f;
-            yield return LMotion.Create(1f, endValue, Duration).BindToPositionZ(target).ToYieldInteraction();
+            yield return LMotion.Create(1f, endValue, Duration).BindToPositionZ(target).ToYieldInstruction();
             Assert.That(target.position.z, Is.EqualTo(endValue).Using(FloatEqualityComparer.Instance));
         }
-        
+
         [UnityTest]
         public IEnumerator Test_BindToPositionXY()
         {
             var endValue = Vector2.one;
-            yield return LMotion.Create(Vector2.zero, endValue, Duration).BindToPositionXY(target).ToYieldInteraction();
+            yield return LMotion.Create(Vector2.zero, endValue, Duration).BindToPositionXY(target).ToYieldInstruction();
             Assert.That(new Vector2(target.position.x, target.position.y), Is.EqualTo(endValue).Using(Vector2EqualityComparer.Instance));
         }
-        
+
         [UnityTest]
         public IEnumerator Test_BindToPositionXZ()
         {
             var endValue = Vector2.one;
-            yield return LMotion.Create(Vector2.zero, endValue, Duration).BindToPositionXZ(target).ToYieldInteraction();
+            yield return LMotion.Create(Vector2.zero, endValue, Duration).BindToPositionXZ(target).ToYieldInstruction();
             Assert.That(new Vector2(target.position.x, target.position.z), Is.EqualTo(endValue).Using(Vector2EqualityComparer.Instance));
         }
-        
+
         [UnityTest]
         public IEnumerator Test_BindToPositionYZ()
         {
             var endValue = Vector2.one;
-            yield return LMotion.Create(Vector2.zero, endValue, Duration).BindToPositionYZ(target).ToYieldInteraction();
+            yield return LMotion.Create(Vector2.zero, endValue, Duration).BindToPositionYZ(target).ToYieldInstruction();
             Assert.That(new Vector2(target.position.y, target.position.z), Is.EqualTo(endValue).Using(Vector2EqualityComparer.Instance));
         }
 
@@ -84,7 +84,7 @@ namespace LitMotion.Tests.Runtime
         public IEnumerator Test_BindToLocalPosition()
         {
             var endValue = Vector3.one;
-            yield return LMotion.Create(Vector3.zero, endValue, Duration).BindToLocalPosition(target).ToYieldInteraction();
+            yield return LMotion.Create(Vector3.zero, endValue, Duration).BindToLocalPosition(target).ToYieldInstruction();
             Assert.That(target.localPosition, Is.EqualTo(endValue).Using(Vector3EqualityComparer.Instance));
         }
 
@@ -92,7 +92,7 @@ namespace LitMotion.Tests.Runtime
         public IEnumerator Test_BindToLocalPositionX()
         {
             var endValue = 10f;
-            yield return LMotion.Create(1f, endValue, Duration).BindToLocalPositionX(target).ToYieldInteraction();
+            yield return LMotion.Create(1f, endValue, Duration).BindToLocalPositionX(target).ToYieldInstruction();
             Assert.That(target.localPosition.x, Is.EqualTo(endValue).Using(FloatEqualityComparer.Instance));
         }
 
@@ -100,7 +100,7 @@ namespace LitMotion.Tests.Runtime
         public IEnumerator Test_BindToLocalPositionY()
         {
             var endValue = 10f;
-            yield return LMotion.Create(1f, endValue, Duration).BindToLocalPositionY(target).ToYieldInteraction();
+            yield return LMotion.Create(1f, endValue, Duration).BindToLocalPositionY(target).ToYieldInstruction();
             Assert.That(target.localPosition.y, Is.EqualTo(endValue).Using(FloatEqualityComparer.Instance));
         }
 
@@ -108,31 +108,31 @@ namespace LitMotion.Tests.Runtime
         public IEnumerator Test_BindToLocalPositionZ()
         {
             var endValue = 10f;
-            yield return LMotion.Create(1f, endValue, Duration).BindToLocalPositionZ(target).ToYieldInteraction();
+            yield return LMotion.Create(1f, endValue, Duration).BindToLocalPositionZ(target).ToYieldInstruction();
             Assert.That(target.localPosition.z, Is.EqualTo(endValue).Using(FloatEqualityComparer.Instance));
         }
-        
+
         [UnityTest]
         public IEnumerator Test_BindToLocalPositionXY()
         {
             var endValue = Vector2.one;
-            yield return LMotion.Create(Vector2.zero, endValue, Duration).BindToLocalPositionXY(target).ToYieldInteraction();
+            yield return LMotion.Create(Vector2.zero, endValue, Duration).BindToLocalPositionXY(target).ToYieldInstruction();
             Assert.That(new Vector2(target.localPosition.x, target.localPosition.y), Is.EqualTo(endValue).Using(Vector2EqualityComparer.Instance));
         }
-        
+
         [UnityTest]
         public IEnumerator Test_BindToLocalPositionXZ()
         {
             var endValue = Vector2.one;
-            yield return LMotion.Create(Vector2.zero, endValue, Duration).BindToLocalPositionXZ(target).ToYieldInteraction();
+            yield return LMotion.Create(Vector2.zero, endValue, Duration).BindToLocalPositionXZ(target).ToYieldInstruction();
             Assert.That(new Vector2(target.localPosition.x, target.localPosition.z), Is.EqualTo(endValue).Using(Vector2EqualityComparer.Instance));
         }
-        
+
         [UnityTest]
         public IEnumerator Test_BindToLocalPositionYZ()
         {
             var endValue = Vector2.one;
-            yield return LMotion.Create(Vector2.zero, endValue, Duration).BindToLocalPositionYZ(target).ToYieldInteraction();
+            yield return LMotion.Create(Vector2.zero, endValue, Duration).BindToLocalPositionYZ(target).ToYieldInstruction();
             Assert.That(new Vector2(target.localPosition.y, target.localPosition.z), Is.EqualTo(endValue).Using(Vector2EqualityComparer.Instance));
         }
 
@@ -140,7 +140,7 @@ namespace LitMotion.Tests.Runtime
         public IEnumerator Test_BindToRotation()
         {
             var endValue = Quaternion.Euler(10f, 20f, 30f);
-            yield return LMotion.Create(Quaternion.identity, endValue, Duration).BindToRotation(target).ToYieldInteraction();
+            yield return LMotion.Create(Quaternion.identity, endValue, Duration).BindToRotation(target).ToYieldInstruction();
             Assert.That(target.rotation, Is.EqualTo(endValue).Using(QuaternionEqualityComparer.Instance));
         }
 
@@ -148,7 +148,7 @@ namespace LitMotion.Tests.Runtime
         public IEnumerator Test_BindToLocalRotation()
         {
             var endValue = Quaternion.Euler(10f, 20f, 30f);
-            yield return LMotion.Create(Quaternion.identity, endValue, Duration).BindToLocalRotation(target).ToYieldInteraction();
+            yield return LMotion.Create(Quaternion.identity, endValue, Duration).BindToLocalRotation(target).ToYieldInstruction();
             Assert.That(target.localRotation, Is.EqualTo(endValue).Using(QuaternionEqualityComparer.Instance));
         }
 
@@ -156,7 +156,7 @@ namespace LitMotion.Tests.Runtime
         public IEnumerator Test_BindToEulerAngles()
         {
             var endValue = Vector3.one * 10f;
-            yield return LMotion.Create(Vector3.zero, endValue, Duration).BindToEulerAngles(target).ToYieldInteraction();
+            yield return LMotion.Create(Vector3.zero, endValue, Duration).BindToEulerAngles(target).ToYieldInstruction();
             Assert.That(target.eulerAngles, Is.EqualTo(endValue).Using(Vector3EqualityComparer.Instance));
         }
 
@@ -164,7 +164,7 @@ namespace LitMotion.Tests.Runtime
         public IEnumerator Test_BindToEulerAnglesX()
         {
             var endValue = 10f;
-            yield return LMotion.Create(0f, endValue, Duration).BindToEulerAnglesX(target).ToYieldInteraction();
+            yield return LMotion.Create(0f, endValue, Duration).BindToEulerAnglesX(target).ToYieldInstruction();
             Assert.That(target.eulerAngles.x, Is.EqualTo(endValue).Using(FloatEqualityComparer.Instance));
         }
 
@@ -172,7 +172,7 @@ namespace LitMotion.Tests.Runtime
         public IEnumerator Test_BindToEulerAnglesY()
         {
             var endValue = 10f;
-            yield return LMotion.Create(0f, endValue, Duration).BindToEulerAnglesY(target).ToYieldInteraction();
+            yield return LMotion.Create(0f, endValue, Duration).BindToEulerAnglesY(target).ToYieldInstruction();
             Assert.That(target.eulerAngles.y, Is.EqualTo(endValue).Using(FloatEqualityComparer.Instance));
         }
 
@@ -180,31 +180,31 @@ namespace LitMotion.Tests.Runtime
         public IEnumerator Test_BindToEulerAnglesZ()
         {
             var endValue = 10f;
-            yield return LMotion.Create(0f, endValue, Duration).BindToEulerAnglesZ(target).ToYieldInteraction();
+            yield return LMotion.Create(0f, endValue, Duration).BindToEulerAnglesZ(target).ToYieldInstruction();
             Assert.That(target.eulerAngles.z, Is.EqualTo(endValue).Using(FloatEqualityComparer.Instance));
         }
-        
+
         [UnityTest]
         public IEnumerator Test_BindToEulerAnglesXY()
         {
             var endValue = Vector2.one * 10f;
-            yield return LMotion.Create(Vector2.zero, endValue, Duration).BindToEulerAnglesXY(target).ToYieldInteraction();
+            yield return LMotion.Create(Vector2.zero, endValue, Duration).BindToEulerAnglesXY(target).ToYieldInstruction();
             Assert.That(new Vector2(target.eulerAngles.x, target.eulerAngles.y), Is.EqualTo(endValue).Using(Vector2EqualityComparer.Instance));
         }
-        
+
         [UnityTest]
         public IEnumerator Test_BindToEulerAnglesXZ()
         {
             var endValue = Vector2.one * 10f;
-            yield return LMotion.Create(Vector2.zero, endValue, Duration).BindToEulerAnglesXZ(target).ToYieldInteraction();
+            yield return LMotion.Create(Vector2.zero, endValue, Duration).BindToEulerAnglesXZ(target).ToYieldInstruction();
             Assert.That(new Vector2(target.eulerAngles.x, target.eulerAngles.z), Is.EqualTo(endValue).Using(Vector2EqualityComparer.Instance));
         }
-        
+
         [UnityTest]
         public IEnumerator Test_BindToEulerAnglesYZ()
         {
             var endValue = Vector2.one * 10f;
-            yield return LMotion.Create(Vector2.zero, endValue, Duration).BindToEulerAnglesYZ(target).ToYieldInteraction();
+            yield return LMotion.Create(Vector2.zero, endValue, Duration).BindToEulerAnglesYZ(target).ToYieldInstruction();
             Assert.That(new Vector2(target.eulerAngles.y, target.eulerAngles.z), Is.EqualTo(endValue).Using(Vector2EqualityComparer.Instance));
         }
 
@@ -212,7 +212,7 @@ namespace LitMotion.Tests.Runtime
         public IEnumerator Test_BindToLocalEulerAngles()
         {
             var endValue = Vector3.one * 10f;
-            yield return LMotion.Create(Vector3.zero, endValue, Duration).BindToLocalEulerAngles(target).ToYieldInteraction();
+            yield return LMotion.Create(Vector3.zero, endValue, Duration).BindToLocalEulerAngles(target).ToYieldInstruction();
             Assert.That(target.localEulerAngles, Is.EqualTo(endValue).Using(Vector3EqualityComparer.Instance));
         }
 
@@ -220,7 +220,7 @@ namespace LitMotion.Tests.Runtime
         public IEnumerator Test_BindToLocalEulerAnglesX()
         {
             var endValue = 10f;
-            yield return LMotion.Create(0f, endValue, Duration).BindToLocalEulerAnglesX(target).ToYieldInteraction();
+            yield return LMotion.Create(0f, endValue, Duration).BindToLocalEulerAnglesX(target).ToYieldInstruction();
             Assert.That(target.localEulerAngles.x, Is.EqualTo(endValue).Using(FloatEqualityComparer.Instance));
         }
 
@@ -228,7 +228,7 @@ namespace LitMotion.Tests.Runtime
         public IEnumerator Test_BindToLocalEulerAnglesY()
         {
             var endValue = 10f;
-            yield return LMotion.Create(0f, endValue, Duration).BindToLocalEulerAnglesY(target).ToYieldInteraction();
+            yield return LMotion.Create(0f, endValue, Duration).BindToLocalEulerAnglesY(target).ToYieldInstruction();
             Assert.That(target.localEulerAngles.y, Is.EqualTo(endValue).Using(FloatEqualityComparer.Instance));
         }
 
@@ -236,31 +236,31 @@ namespace LitMotion.Tests.Runtime
         public IEnumerator Test_BindToLocalEulerAnglesZ()
         {
             var endValue = 10f;
-            yield return LMotion.Create(0f, endValue, Duration).BindToLocalEulerAnglesZ(target).ToYieldInteraction();
+            yield return LMotion.Create(0f, endValue, Duration).BindToLocalEulerAnglesZ(target).ToYieldInstruction();
             Assert.That(target.localEulerAngles.z, Is.EqualTo(endValue).Using(FloatEqualityComparer.Instance));
         }
-        
+
         [UnityTest]
         public IEnumerator Test_BindToLocalEulerAnglesXY()
         {
             var endValue = Vector2.one * 10f;
-            yield return LMotion.Create(Vector2.zero, endValue, Duration).BindToLocalEulerAnglesXY(target).ToYieldInteraction();
+            yield return LMotion.Create(Vector2.zero, endValue, Duration).BindToLocalEulerAnglesXY(target).ToYieldInstruction();
             Assert.That(new Vector2(target.localEulerAngles.x, target.localEulerAngles.y), Is.EqualTo(endValue).Using(Vector2EqualityComparer.Instance));
         }
-        
+
         [UnityTest]
         public IEnumerator Test_BindToLocalEulerAnglesXZ()
         {
             var endValue = Vector2.one * 10f;
-            yield return LMotion.Create(Vector2.zero, endValue, Duration).BindToLocalEulerAnglesXZ(target).ToYieldInteraction();
+            yield return LMotion.Create(Vector2.zero, endValue, Duration).BindToLocalEulerAnglesXZ(target).ToYieldInstruction();
             Assert.That(new Vector2(target.localEulerAngles.x, target.localEulerAngles.z), Is.EqualTo(endValue).Using(Vector2EqualityComparer.Instance));
         }
-        
+
         [UnityTest]
         public IEnumerator Test_BindToLocalEulerAnglesYZ()
         {
             var endValue = Vector2.one * 10f;
-            yield return LMotion.Create(Vector2.zero, endValue, Duration).BindToLocalEulerAnglesYZ(target).ToYieldInteraction();
+            yield return LMotion.Create(Vector2.zero, endValue, Duration).BindToLocalEulerAnglesYZ(target).ToYieldInstruction();
             Assert.That(new Vector2(target.localEulerAngles.y, target.localEulerAngles.z), Is.EqualTo(endValue).Using(Vector2EqualityComparer.Instance));
         }
 
@@ -268,7 +268,7 @@ namespace LitMotion.Tests.Runtime
         public IEnumerator Test_BindToLocalScale()
         {
             var endValue = Vector3.one * 2f;
-            yield return LMotion.Create(Vector3.one, endValue, Duration).BindToLocalScale(target).ToYieldInteraction();
+            yield return LMotion.Create(Vector3.one, endValue, Duration).BindToLocalScale(target).ToYieldInstruction();
             Assert.That(target.localScale, Is.EqualTo(endValue).Using(Vector3EqualityComparer.Instance));
         }
 
@@ -276,7 +276,7 @@ namespace LitMotion.Tests.Runtime
         public IEnumerator Test_BindToLocalScaleX()
         {
             var endValue = 2f;
-            yield return LMotion.Create(1f, endValue, Duration).BindToLocalScaleX(target).ToYieldInteraction();
+            yield return LMotion.Create(1f, endValue, Duration).BindToLocalScaleX(target).ToYieldInstruction();
             Assert.That(target.localScale.x, Is.EqualTo(endValue).Using(FloatEqualityComparer.Instance));
         }
 
@@ -284,7 +284,7 @@ namespace LitMotion.Tests.Runtime
         public IEnumerator Test_BindToLocalScaleY()
         {
             var endValue = 2f;
-            yield return LMotion.Create(1f, endValue, Duration).BindToLocalScaleY(target).ToYieldInteraction();
+            yield return LMotion.Create(1f, endValue, Duration).BindToLocalScaleY(target).ToYieldInstruction();
             Assert.That(target.localScale.y, Is.EqualTo(endValue).Using(FloatEqualityComparer.Instance));
         }
 
@@ -292,31 +292,31 @@ namespace LitMotion.Tests.Runtime
         public IEnumerator Test_BindToLocalScaleZ()
         {
             var endValue = 2f;
-            yield return LMotion.Create(1f, endValue, Duration).BindToLocalScaleZ(target).ToYieldInteraction();
+            yield return LMotion.Create(1f, endValue, Duration).BindToLocalScaleZ(target).ToYieldInstruction();
             Assert.That(target.localScale.z, Is.EqualTo(endValue).Using(FloatEqualityComparer.Instance));
         }
-        
+
         [UnityTest]
         public IEnumerator Test_BindToLocalScaleXY()
         {
             var endValue = Vector2.one * 2f;
-            yield return LMotion.Create(Vector2.one, endValue, Duration).BindToLocalScaleXY(target).ToYieldInteraction();
+            yield return LMotion.Create(Vector2.one, endValue, Duration).BindToLocalScaleXY(target).ToYieldInstruction();
             Assert.That(new Vector2(target.localScale.x, target.localScale.y), Is.EqualTo(endValue).Using(Vector2EqualityComparer.Instance));
         }
-        
+
         [UnityTest]
         public IEnumerator Test_BindToLocalScaleXZ()
         {
             var endValue = Vector2.one * 2f;
-            yield return LMotion.Create(Vector2.one, endValue, Duration).BindToLocalScaleXZ(target).ToYieldInteraction();
+            yield return LMotion.Create(Vector2.one, endValue, Duration).BindToLocalScaleXZ(target).ToYieldInstruction();
             Assert.That(new Vector2(target.localScale.x, target.localScale.z), Is.EqualTo(endValue).Using(Vector2EqualityComparer.Instance));
         }
-        
+
         [UnityTest]
         public IEnumerator Test_BindToLocalScaleYZ()
         {
             var endValue = Vector2.one * 2f;
-            yield return LMotion.Create(Vector2.one, endValue, Duration).BindToLocalScaleYZ(target).ToYieldInteraction();
+            yield return LMotion.Create(Vector2.one, endValue, Duration).BindToLocalScaleYZ(target).ToYieldInstruction();
             Assert.That(new Vector2(target.localScale.y, target.localScale.z), Is.EqualTo(endValue).Using(Vector2EqualityComparer.Instance));
         }
     }


### PR DESCRIPTION
Fix a naming mistake. It should have been named `ToYieldInstruction()`.