### PR TITLE
Add: LitMotion.Sequences

### DIFF
--- a/src/LitMotion/Assets/LitMotion/Runtime/AssemblyInfo.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
 
+[assembly: InternalsVisibleTo("LitMotion.Sequences")]
 [assembly: InternalsVisibleTo("LitMotion.Extensions")]
 [assembly: InternalsVisibleTo("LitMotion.Editor")]
 [assembly: InternalsVisibleTo("LitMotion.Tests.Runtime")]

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionData.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionData.cs
@@ -12,6 +12,7 @@ namespace LitMotion
         public float PlaybackSpeed;
         public bool IsPreserved;
         public bool WasStatusChanged;
+        public bool SkipUpdate;
 
         // parameters
         public float Duration;

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionManager.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionManager.cs
@@ -75,6 +75,13 @@ namespace LitMotion
             list[handle.StorageId].SetTime(handle, time);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void AddToSequence(ref MotionHandle handle, out double motionDuration)
+        {
+            CheckTypeId(handle);
+            list[handle.StorageId].AddToSequence(ref handle, out motionDuration);
+        }
+
         // For MotionTracker
         public static (Type ValueType, Type OptionsType, Type AdapterType) GetMotionType(MotionHandle handle)
         {

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionStorage.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionStorage.cs
@@ -433,8 +433,8 @@ namespace LitMotion
             dataRef.Core.IsPreserved = true;
             dataRef.Core.SkipUpdate = true;
 
-            ref var managedDataRef = ref managedDataArray[slot.DenseIndex];
-            managedDataRef.SkipValuesDuringDelay = true;
+            // ref var managedDataRef = ref managedDataArray[slot.DenseIndex];
+            // managedDataRef.SkipValuesDuringDelay = true;
 
             // increment version
             slot.Version++;

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/UpdateRunner.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/UpdateRunner.cs
@@ -63,6 +63,9 @@ namespace LitMotion
                 for (int i = 0; i < managedDataSpan.Length; i++)
                 {
                     var currentDataPtr = dataPtr + i;
+
+                    if (currentDataPtr->Core.SkipUpdate) continue;
+
                     var status = currentDataPtr->Core.Status;
                     ref var managedData = ref managedDataSpan[i];
                     if (status == MotionStatus.Playing || (status == MotionStatus.Delayed && !managedData.SkipValuesDuringDelay))

--- a/src/LitMotion/Assets/LitMotion/Runtime/MotionHandleExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/MotionHandleExtensions.cs
@@ -28,7 +28,7 @@ namespace LitMotion
         {
             MotionManager.GetDataRef(handle).IsPreserved = true;
         }
-
+    
         /// <summary>
         /// Complete motion.
         /// </summary>

--- a/src/LitMotion/Assets/LitMotion/Runtime/MotionUpdateJob.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/MotionUpdateJob.cs
@@ -35,6 +35,8 @@ namespace LitMotion
             if (Hint.Likely(corePtr->Status is MotionStatus.Scheduled or MotionStatus.Delayed or MotionStatus.Playing) ||
                 Hint.Unlikely(corePtr->IsPreserved && corePtr->Status is MotionStatus.Completed))
             {
+                if (Hint.Unlikely(corePtr->SkipUpdate)) return;
+
                 var deltaTime = corePtr->TimeKind switch
                 {
                     MotionTimeKind.Time => DeltaTime,

--- a/src/LitMotion/Assets/LitMotion/Runtime/Sequences.meta
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Sequences.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0ba8bf58526f94c4ab397f98ed61fdce
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/LitMotion/Assets/LitMotion/Runtime/Sequences/LSequence.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Sequences/LSequence.cs
@@ -1,0 +1,10 @@
+namespace LitMotion.Sequences
+{
+    public static class LSequence
+    {
+        public static MotionSequenceBuilder Create()
+        {
+            return new MotionSequenceBuilder();
+        }
+    }
+}

--- a/src/LitMotion/Assets/LitMotion/Runtime/Sequences/LSequence.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Sequences/LSequence.cs
@@ -4,7 +4,8 @@ namespace LitMotion.Sequences
     {
         public static MotionSequenceBuilder Create()
         {
-            return new MotionSequenceBuilder();
+            var source = MotionSequenceBuilderSource.Rent();
+            return new MotionSequenceBuilder(source);
         }
     }
 }

--- a/src/LitMotion/Assets/LitMotion/Runtime/Sequences/LSequence.cs.meta
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Sequences/LSequence.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c5490814ee06b4422bef0bb5dac59977

--- a/src/LitMotion/Assets/LitMotion/Runtime/Sequences/LitMotion.Sequences.asmdef
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Sequences/LitMotion.Sequences.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "LitMotion.Sequences",
+    "rootNamespace": "",
+    "references": [
+        "GUID:3b570a5146f9d4f0fa107ed4559471a3"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/src/LitMotion/Assets/LitMotion/Runtime/Sequences/LitMotion.Sequences.asmdef.meta
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Sequences/LitMotion.Sequences.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: aa9cad64d4fae43d2a90e595aea6cc7f
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceBuilder.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceBuilder.cs
@@ -1,21 +1,51 @@
 using System;
 using System.Buffers;
 using System.Runtime.CompilerServices;
+using LitMotion.Collections;
 
 namespace LitMotion.Sequences
 {
-    public struct MotionSequenceBuilder : IDisposable
+    internal sealed class MotionSequenceBuilderSource : ILinkedPoolNode<MotionSequenceBuilderSource>
     {
+        static LinkedPool<MotionSequenceBuilderSource> pool;
+
+        public static MotionSequenceBuilderSource Rent()
+        {
+            if (!pool.TryPop(out var result)) result = new();
+            return result;
+        }
+
+        public static void Return(MotionSequenceBuilderSource source)
+        {
+            if (source.buffer != null)
+            {
+                ArrayPool<MotionSequenceItem>.Shared.Return(source.buffer);
+            }
+
+            source.version++;
+            source.buffer = null;
+            source.tail = 0;
+            source.count = 0;
+            source.duration = 0;
+
+            pool.TryPush(source);
+        }
+
+        public ref MotionSequenceBuilderSource NextNode => ref next;
+        public ushort Version => version;
+
+        MotionSequenceBuilderSource next;
+        ushort version;
         MotionSequenceItem[] buffer;
         int count;
-
         double tail;
         double duration;
 
-        public MotionSequenceBuilder Append(MotionHandle handle)
+        public void Append(MotionHandle handle)
         {
             handle.Preserve();
             handle.PlaybackSpeed = 0;
+            MotionManager.GetManagedDataRef(handle).SkipValuesDuringDelay = true;
 
             var motionDuration = handle.Duration;
             if (double.IsInfinity(motionDuration))
@@ -26,13 +56,13 @@ namespace LitMotion.Sequences
             AddItem(new MotionSequenceItem(tail, handle));
             tail += motionDuration;
             duration += motionDuration;
-            return this;
         }
 
-        public MotionSequenceBuilder Insert(double position, MotionHandle handle)
+        public void Insert(double position, MotionHandle handle)
         {
             handle.Preserve();
             handle.PlaybackSpeed = 0;
+            MotionManager.GetManagedDataRef(handle).SkipValuesDuringDelay = true;
 
             var motionDuration = handle.Duration;
             if (double.IsInfinity(motionDuration))
@@ -42,7 +72,18 @@ namespace LitMotion.Sequences
 
             AddItem(new MotionSequenceItem(position, handle));
             duration = Math.Max(duration, position + motionDuration);
-            return this;
+        }
+
+        public MotionHandle Run()
+        {
+            var source = MotionSequenceSource.Rent();
+            var handle = LMotion.Create(0.0, duration, (float)duration)
+                .WithOnComplete(source.OnCompleteDelegate)
+                .WithOnCancel(source.OnCancelDelegate)
+                .Bind(source, (x, source) => source.Time = x);
+
+            source.Initialize(handle, buffer.AsSpan(0, count), duration);
+            return handle;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -62,25 +103,55 @@ namespace LitMotion.Sequences
             buffer[count] = item;
             count++;
         }
+    }
+
+    public struct MotionSequenceBuilder : IDisposable
+    {
+        internal MotionSequenceBuilderSource source;
+        internal ushort version;
+
+        internal MotionSequenceBuilder(MotionSequenceBuilderSource source)
+        {
+            this.source = source;
+            this.version = source.Version;
+        }
+
+        public MotionSequenceBuilder Append(MotionHandle handle)
+        {
+            CheckIsDisposed();
+            source.Append(handle);
+            return this;
+        }
+
+        public MotionSequenceBuilder Insert(double position, MotionHandle handle)
+        {
+            CheckIsDisposed();
+            source.Insert(position, handle);
+            return this;
+        }
 
         public MotionHandle Run()
         {
-            var source = MotionSequenceSource.Rent();
-            var handle = LMotion.Create(0.0, duration, (float)duration)
-                .WithOnComplete(source.OnCompleteDelegate)
-                .WithOnCancel(source.OnCancelDelegate)
-                .Bind(source, (x, source) => source.Time = x);
-
-            source.Initialize(handle, buffer.AsSpan(0, count), duration);
+            CheckIsDisposed();
+            var handle = source.Run();
             Dispose();
             return handle;
         }
 
         public void Dispose()
         {
-            ArrayPool<MotionSequenceItem>.Shared.Return(buffer);
-            buffer = null;
-            tail = 0;
+            CheckIsDisposed();
+            MotionSequenceBuilderSource.Return(source);
+            source = null;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        readonly void CheckIsDisposed()
+        {
+            if (source == null || source.Version != version)
+            {
+                throw new InvalidOperationException("MotionSequenuceBuilder is either not initialized or has already run.");
+            }
         }
     }
 }

--- a/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceBuilder.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceBuilder.cs
@@ -77,8 +77,8 @@ namespace LitMotion.Sequences
                 .WithOnCancel(source.OnCancelDelegate)
                 .Bind(source, (x, source) => source.Time = x);
 
-            Array.Sort(buffer, 0, count);
-            source.Initialize(handle, buffer.AsSpan(0, count), duration);
+            source.Initialize(handle, buffer, count, duration);
+            buffer = null;
             return handle;
         }
 

--- a/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceBuilder.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceBuilder.cs
@@ -65,10 +65,15 @@ namespace LitMotion.Sequences
 
         public MotionHandle Run()
         {
-            var sequence = new MotionSequenceSource(buffer.AsSpan(0, count).ToArray(), duration);
+            var source = MotionSequenceSource.Rent();
+            var handle = LMotion.Create(0.0, duration, (float)duration)
+                .WithOnComplete(source.OnCompleteDelegate)
+                .WithOnCancel(source.OnCancelDelegate)
+                .Bind(source, (x, source) => source.Time = x);
+
+            source.Initialize(handle, buffer.AsSpan(0, count), duration);
             Dispose();
-            return LMotion.Create(0.0, sequence.Duration, (float)sequence.Duration)
-                .Bind(sequence, (x, sequence) => sequence.Time = x);
+            return handle;
         }
 
         public void Dispose()

--- a/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceBuilder.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceBuilder.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Buffers;
+using System.Runtime.CompilerServices;
+
+namespace LitMotion.Sequences
+{
+    public struct MotionSequenceBuilder : IDisposable
+    {
+        MotionSequenceItem[] buffer;
+        int count;
+
+        double tail;
+        double duration;
+
+        public MotionSequenceBuilder Append(MotionHandle handle)
+        {
+            handle.Preserve();
+            handle.PlaybackSpeed = 0;
+
+            var motionDuration = handle.Duration;
+            if (double.IsInfinity(motionDuration))
+            {
+                throw new ArgumentException(); // TODO:
+            }
+
+            AddItem(new MotionSequenceItem(tail, handle));
+            tail += motionDuration;
+            duration += motionDuration;
+            return this;
+        }
+
+        public MotionSequenceBuilder Insert(double position, MotionHandle handle)
+        {
+            handle.Preserve();
+            handle.PlaybackSpeed = 0;
+
+            var motionDuration = handle.Duration;
+            if (double.IsInfinity(motionDuration))
+            {
+                throw new ArgumentException(); // TODO:
+            }
+
+            AddItem(new MotionSequenceItem(position, handle));
+            duration = Math.Max(duration, position + motionDuration);
+            return this;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        void AddItem(in MotionSequenceItem item)
+        {
+            if (buffer == null)
+            {
+                buffer = ArrayPool<MotionSequenceItem>.Shared.Rent(32);
+            }
+            else if (buffer.Length == count)
+            {
+                var newBuffer = ArrayPool<MotionSequenceItem>.Shared.Rent(count * 2);
+                ArrayPool<MotionSequenceItem>.Shared.Return(buffer);
+                buffer = newBuffer;
+            }
+
+            buffer[count] = item;
+            count++;
+        }
+
+        public MotionHandle Run()
+        {
+            var sequence = new MotionSequenceSource(buffer.AsSpan(0, count).ToArray(), duration);
+            Dispose();
+            return LMotion.Create(0.0, sequence.Duration, (float)sequence.Duration)
+                .Bind(sequence, (x, sequence) => sequence.Time = x);
+        }
+
+        public void Dispose()
+        {
+            ArrayPool<MotionSequenceItem>.Shared.Return(buffer);
+            buffer = null;
+            tail = 0;
+        }
+    }
+}

--- a/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceBuilder.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceBuilder.cs
@@ -145,7 +145,7 @@ namespace LitMotion.Sequences
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public MotionHandle Run()
+        public MotionHandle Schedule()
         {
             CheckIsDisposed();
             var handle = source.Run();

--- a/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceBuilder.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceBuilder.cs
@@ -48,10 +48,7 @@ namespace LitMotion.Sequences
             MotionManager.GetManagedDataRef(handle).SkipValuesDuringDelay = true;
 
             var motionDuration = handle.Duration;
-            if (double.IsInfinity(motionDuration))
-            {
-                throw new ArgumentException(); // TODO:
-            }
+            ThrowIfDurationIsInfinity(motionDuration);
 
             AddItem(new MotionSequenceItem(tail, handle));
             tail += motionDuration;
@@ -65,10 +62,7 @@ namespace LitMotion.Sequences
             MotionManager.GetManagedDataRef(handle).SkipValuesDuringDelay = true;
 
             var motionDuration = handle.Duration;
-            if (double.IsInfinity(motionDuration))
-            {
-                throw new ArgumentException(); // TODO:
-            }
+            ThrowIfDurationIsInfinity(motionDuration);
 
             AddItem(new MotionSequenceItem(position, handle));
             duration = Math.Max(duration, position + motionDuration);
@@ -103,6 +97,14 @@ namespace LitMotion.Sequences
 
             buffer[count] = item;
             count++;
+        }
+
+        void ThrowIfDurationIsInfinity(double duration)
+        {
+            if (double.IsInfinity(duration))
+            {
+                throw new ArgumentException("Cannot add an infinitely looping motion to a sequence.");
+            }
         }
     }
 

--- a/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceBuilder.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceBuilder.cs
@@ -82,6 +82,7 @@ namespace LitMotion.Sequences
                 .WithOnCancel(source.OnCancelDelegate)
                 .Bind(source, (x, source) => source.Time = x);
 
+            Array.Sort(buffer, 0, count);
             source.Initialize(handle, buffer.AsSpan(0, count), duration);
             return handle;
         }
@@ -116,20 +117,23 @@ namespace LitMotion.Sequences
             this.version = source.Version;
         }
 
-        public MotionSequenceBuilder Append(MotionHandle handle)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public readonly MotionSequenceBuilder Append(MotionHandle handle)
         {
             CheckIsDisposed();
             source.Append(handle);
             return this;
         }
 
-        public MotionSequenceBuilder Insert(double position, MotionHandle handle)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public readonly MotionSequenceBuilder Insert(float position, MotionHandle handle)
         {
             CheckIsDisposed();
             source.Insert(position, handle);
             return this;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public MotionHandle Run()
         {
             CheckIsDisposed();
@@ -138,6 +142,7 @@ namespace LitMotion.Sequences
             return handle;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Dispose()
         {
             CheckIsDisposed();

--- a/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceBuilder.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceBuilder.cs
@@ -54,7 +54,7 @@ namespace LitMotion.Sequences
         {
             lastTail = tail;
             tail += interval;
-            duration = Math.Max(duration, tail + interval);
+            duration = Math.Max(duration, tail);
         }
 
         public void Insert(double position, MotionHandle handle)

--- a/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceBuilder.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceBuilder.cs
@@ -43,12 +43,7 @@ namespace LitMotion.Sequences
 
         public void Append(MotionHandle handle)
         {
-            CheckHandle(handle, out var motionDuration);
-
-            handle.Preserve();
-            handle.PlaybackSpeed = 0;
-            MotionManager.GetManagedDataRef(handle).SkipValuesDuringDelay = true;
-
+            MotionManager.AddToSequence(ref handle, out var motionDuration);
             AddItem(new MotionSequenceItem(tail, handle));
             tail += motionDuration;
             duration += motionDuration;
@@ -56,12 +51,7 @@ namespace LitMotion.Sequences
 
         public void Insert(double position, MotionHandle handle)
         {
-            CheckHandle(handle, out var motionDuration);
-
-            handle.Preserve();
-            handle.PlaybackSpeed = 0;
-            MotionManager.GetManagedDataRef(handle).SkipValuesDuringDelay = true;
-
+            MotionManager.AddToSequence(ref handle, out var motionDuration);
             AddItem(new MotionSequenceItem(position, handle));
             duration = Math.Max(duration, position + motionDuration);
         }
@@ -95,21 +85,6 @@ namespace LitMotion.Sequences
 
             buffer[count] = item;
             count++;
-        }
-
-        void CheckHandle(MotionHandle handle, out double motionDuration)
-        {
-            ref var data = ref MotionManager.GetDataRef(handle);
-            if (data.Status is not MotionStatus.Scheduled)
-            {
-                throw new ArgumentException("Cannot add a running motion to a sequence.");
-            }
-
-            motionDuration = handle.Duration;
-            if (double.IsInfinity(motionDuration))
-            {
-                throw new ArgumentException("Cannot add an infinitely looping motion to a sequence.");
-            }
         }
     }
 

--- a/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceBuilder.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceBuilder.cs
@@ -69,7 +69,7 @@ namespace LitMotion.Sequences
             Insert(lastTail, handle);
         }
 
-        public MotionHandle Run()
+        public MotionHandle Schedule()
         {
             var source = MotionSequenceSource.Rent();
             var handle = LMotion.Create(0.0, duration, (float)duration)
@@ -148,7 +148,7 @@ namespace LitMotion.Sequences
         public MotionHandle Schedule()
         {
             CheckIsDisposed();
-            var handle = source.Run();
+            var handle = source.Schedule();
             Dispose();
             return handle;
         }

--- a/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceBuilder.cs.meta
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceBuilder.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f73237f0ff59a4a9899c7fa2d2791c98

--- a/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceSource.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceSource.cs
@@ -1,0 +1,43 @@
+namespace LitMotion.Sequences
+{
+    internal struct MotionSequenceItem
+    {
+        public MotionSequenceItem(double position, MotionHandle handle)
+        {
+            Position = position;
+            Handle = handle;
+        }
+
+        public double Position;
+        public MotionHandle Handle;
+    }
+
+    internal sealed class MotionSequenceSource
+    {
+        internal MotionSequenceSource(MotionSequenceItem[] items, double duration)
+        {
+            this.items = items;
+            this.duration = duration;
+        }
+
+        readonly MotionSequenceItem[] items;
+        double duration;
+        double time;
+
+        public double Time
+        {
+            get => time;
+            set
+            {
+                time = value;
+
+                foreach (var item in items)
+                {
+                    item.Handle.Time = time;
+                }
+            }
+        }
+
+        public double Duration => duration;
+    }
+}

--- a/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceSource.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceSource.cs
@@ -51,7 +51,7 @@ namespace LitMotion.Sequences
         {
             onCompleteDelegate = () =>
             {
-                if (!MotionManager.GetDataRef(handle).IsPreserved)
+                if (MotionManager.IsActive(handle) && !MotionManager.GetDataRef(handle).IsPreserved)
                 {
                     Return(this);
                 }

--- a/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceSource.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceSource.cs
@@ -78,7 +78,7 @@ namespace LitMotion.Sequences
 
                 foreach (var item in itemsBuffer.AsSpan(0, itemCount))
                 {
-                    item.Handle.Time = time;
+                    item.Handle.Time = time - item.Position;
                 }
             }
         }

--- a/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceSource.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceSource.cs
@@ -4,7 +4,7 @@ using LitMotion.Collections;
 
 namespace LitMotion.Sequences
 {
-    internal struct MotionSequenceItem
+    internal struct MotionSequenceItem : IComparable<MotionSequenceItem>
     {
         public MotionSequenceItem(double position, MotionHandle handle)
         {
@@ -14,6 +14,11 @@ namespace LitMotion.Sequences
 
         public double Position;
         public MotionHandle Handle;
+
+        public int CompareTo(MotionSequenceItem other)
+        {
+            return Position.CompareTo(other.Position);
+        }
     }
 
     internal sealed class MotionSequenceSource : ILinkedPoolNode<MotionSequenceSource>

--- a/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceSource.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceSource.cs
@@ -45,6 +45,7 @@ namespace LitMotion.Sequences
             this.itemsBuffer = ArrayPool<MotionSequenceItem>.Shared.Rent(itemCount);
             items.CopyTo(this.itemsBuffer);
             this.duration = duration;
+            this.time = 0;
         }
 
         MotionSequenceSource()

--- a/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceSource.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceSource.cs
@@ -33,19 +33,20 @@ namespace LitMotion.Sequences
 
         public static void Return(MotionSequenceSource source)
         {
-            ArrayPool<MotionSequenceItem>.Shared.Return(source.itemsBuffer);
-            source.itemsBuffer = null;
+            ArrayPool<MotionSequenceItem>.Shared.Return(source.itemBuffer);
+            source.itemBuffer = null;
             pool.TryPush(source);
         }
 
-        public void Initialize(MotionHandle handle, ReadOnlySpan<MotionSequenceItem> sortedItems, double duration)
+        public void Initialize(MotionHandle handle, MotionSequenceItem[] itemBuffer, int itemCount, double duration)
         {
             this.handle = handle;
-            this.itemCount = sortedItems.Length;
-            this.itemsBuffer = ArrayPool<MotionSequenceItem>.Shared.Rent(itemCount);
-            sortedItems.CopyTo(this.itemsBuffer);
+            this.itemCount = itemCount;
+            this.itemBuffer = itemBuffer;
             this.duration = duration;
             this.time = 0;
+
+            Array.Sort(itemBuffer, 0, itemCount);
         }
 
         MotionSequenceSource()
@@ -65,7 +66,7 @@ namespace LitMotion.Sequences
         MotionSequenceSource next;
 
         MotionHandle handle;
-        MotionSequenceItem[] itemsBuffer;
+        MotionSequenceItem[] itemBuffer;
         int itemCount;
         double duration;
         double time;
@@ -82,7 +83,7 @@ namespace LitMotion.Sequences
             {
                 time = value;
 
-                var span = itemsBuffer.AsSpan(0, itemCount);
+                var span = itemBuffer.AsSpan(0, itemCount);
 
                 var index = span.Length - 1;
                 while (index >= 0)

--- a/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceSource.cs.meta
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceSource.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b9f408f44ddbb405ab0a1a5542af5f7e

--- a/src/LitMotion/Assets/LitMotion/Tests/Runtime/LitMotion.Tests.Runtime.asmdef
+++ b/src/LitMotion/Assets/LitMotion/Tests/Runtime/LitMotion.Tests.Runtime.asmdef
@@ -7,6 +7,7 @@
         "Unity.Burst",
         "Unity.Collections",
         "LitMotion",
+        "LitMotion.Sequences",
         "LitMotion.Extensions",
         "UniTask",
         "UniRx"

--- a/src/LitMotion/Assets/LitMotion/Tests/Runtime/SequenceTest.cs
+++ b/src/LitMotion/Assets/LitMotion/Tests/Runtime/SequenceTest.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections;
+using LitMotion.Sequences;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace LitMotion.Tests.Runtime
+{
+    public class SequenceTest
+    {
+        [UnityTest]
+        public IEnumerator Test_Append()
+        {
+            var x = 0f;
+            var y = 0f;
+
+            LSequence.Create()
+                .Append(LMotion.Create(0f, 1f, 0.2f).Bind(v => x = v))
+                .Append(LMotion.Create(0f, 1f, 0.2f).Bind(v => y = v))
+                .Schedule();
+
+            yield return new WaitForSeconds(0.21f);
+            Assert.That(x, Is.EqualTo(1f));
+            yield return new WaitForSeconds(0.21f);
+            Assert.That(y, Is.EqualTo(1f));
+        }
+
+        [UnityTest]
+        public IEnumerator Test_Join()
+        {
+            var x = 0f;
+            var y = 0f;
+
+            LSequence.Create()
+                .Join(LMotion.Create(0f, 1f, 0.2f).Bind(v => x = v))
+                .Join(LMotion.Create(0f, 1f, 0.2f).Bind(v => y = v))
+                .Schedule();
+
+            yield return new WaitForSeconds(0.21f);
+            Assert.That(x, Is.EqualTo(1f));
+            Assert.That(y, Is.EqualTo(1f));
+        }
+
+        [UnityTest]
+        public IEnumerator Test_Insert()
+        {
+            var x = 0f;
+            var y = 0f;
+
+            LSequence.Create()
+                .Append(LMotion.Create(0f, 1f, 0.2f).Bind(v => x = v))
+                .Insert(0.1f, LMotion.Create(0f, 1f, 0.2f).Bind(v => y = v))
+                .Schedule();
+
+            yield return new WaitForSeconds(0.21f);
+            Assert.That(x, Is.EqualTo(1f));
+            yield return new WaitForSeconds(0.11f);
+            Assert.That(y, Is.EqualTo(1f));
+        }
+
+        [UnityTest]
+        public IEnumerator Test_AppendInterval()
+        {
+            var x = 0f;
+
+            LSequence.Create()
+                .AppendInterval(0.2f)
+                .Append(LMotion.Create(0f, 1f, 0.2f).Bind(v => x = v))
+                .Schedule();
+
+            yield return new WaitForSeconds(0.19f);
+            Assert.That(x, Is.EqualTo(0f));
+            yield return new WaitForSeconds(0.22f);
+            Assert.That(x, Is.EqualTo(1f));
+        }
+
+        [UnityTest]
+        public IEnumerator Test_Nested_Sequence()
+        {
+            var x = 0f;
+            var y = 0f;
+
+            var sequence1 = LSequence.Create()
+                .Append(LMotion.Create(0f, 1f, 0.2f).Bind(v => x = v))
+                .Append(LMotion.Create(1f, 0f, 0.2f).Bind(v => x = v))
+                .Schedule();
+
+            var sequence2 = LSequence.Create()
+                .Append(LMotion.Create(0f, 1f, 0.2f).Bind(v => y = v))
+                .Append(LMotion.Create(1f, 0f, 0.2f).Bind(v => y = v))
+                .Schedule();
+
+            var handle = LSequence.Create()
+                .Append(sequence1)
+                .Append(sequence2)
+                .Schedule();
+
+            yield return new WaitForSeconds(0.2f);
+            Assert.That(x, Is.GreaterThan(0.9f));
+            Assert.That(y, Is.EqualTo(0f));
+            yield return new WaitForSeconds(0.2f);
+            Assert.That(x, Is.EqualTo(0f));
+            Assert.That(y, Is.LessThan(0.1f));
+            yield return new WaitForSeconds(0.2f);
+            Assert.That(x, Is.EqualTo(0f));
+            Assert.That(y, Is.GreaterThan(0.9f));
+            yield return new WaitForSeconds(0.2f);
+            Assert.That(x, Is.EqualTo(0f));
+            Assert.That(y, Is.EqualTo(0f));
+        }
+
+        [UnityTest]
+        public IEnumerator Test_Error_AppendRunningMotion()
+        {
+            var handle = LMotion.Create(0f, 1f, 10f).RunWithoutBinding();
+            yield return null;
+
+            Assert.Throws<ArgumentException>(() =>
+            {
+                LSequence.Create()
+                    .Append(handle)
+                    .Schedule();
+            }, "Cannot add a running motion to a sequence.");
+        }
+
+        [Test]
+        public void Test_Error_UseMotionHandleInSequence()
+        {
+            var handle = LMotion.Create(0f, 1f, 10f).RunWithoutBinding();
+            LSequence.Create()
+                .Append(handle)
+                .Schedule();
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                handle.Complete();
+            });
+        }
+    }
+}

--- a/src/LitMotion/Assets/LitMotion/Tests/Runtime/SequenceTest.cs.meta
+++ b/src/LitMotion/Assets/LitMotion/Tests/Runtime/SequenceTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 55b26ed55231746e9887d4292aac2cee

--- a/src/LitMotion/Assets/Sandbox/Sandbox.cs
+++ b/src/LitMotion/Assets/Sandbox/Sandbox.cs
@@ -1,17 +1,27 @@
 using LitMotion;
 using LitMotion.Extensions;
+using LitMotion.Sequences;
 using UnityEngine;
+using UnityEngine.UI;
 
 public class Sandbox : MonoBehaviour
 {
     [SerializeField] Transform target;
+    [SerializeField] Slider slider;
+
+    MotionHandle handle;
 
     void Start()
     {
-        LMotion.Create(0f, 5f, 2f)
-            .WithEase(Ease.OutQuint)
-            .WithLoops(-1, LoopType.Yoyo)
-            .BindToPositionX(target)
-            .AddTo(target);
+        handle = LSequence.Create()
+            .Append(LMotion.Create(-5f, 5f, 0.5f).BindToPositionX(target))
+            .Append(LMotion.Create(0f, 5f, 0.5f).BindToPositionY(target))
+            .Append(LMotion.Create(-2f, 2f, 1f).BindToPositionZ(target))
+            .Run();
+    }
+
+    void Update()
+    {
+        handle.Time = slider.value;
     }
 }

--- a/src/LitMotion/Assets/Sandbox/Sandbox.unity
+++ b/src/LitMotion/Assets/Sandbox/Sandbox.unity
@@ -119,6 +119,302 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &183474487
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 183474488}
+  - component: {fileID: 183474489}
+  m_Layer: 5
+  m_Name: Slider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &183474488
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 183474487}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2095547403}
+  - {fileID: 2134075221}
+  - {fileID: 316441678}
+  m_Father: {fileID: 284284924}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 0, y: 60}
+  m_SizeDelta: {x: 200, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &183474489
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 183474487}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 2060399381}
+  m_FillRect: {fileID: 1633886872}
+  m_HandleRect: {fileID: 2060399380}
+  m_Direction: 0
+  m_MinValue: 0
+  m_MaxValue: 1
+  m_WholeNumbers: 0
+  m_Value: 0
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &240099433
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 240099436}
+  - component: {fileID: 240099435}
+  - component: {fileID: 240099434}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &240099434
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 240099433}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
+--- !u!114 &240099435
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 240099433}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &240099436
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 240099433}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &284284920
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 284284924}
+  - component: {fileID: 284284923}
+  - component: {fileID: 284284922}
+  - component: {fileID: 284284921}
+  m_Layer: 5
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &284284921
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 284284920}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &284284922
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 284284920}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 1
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!223 &284284923
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 284284920}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &284284924
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 284284920}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 183474488}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!1 &316441677
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 316441678}
+  m_Layer: 5
+  m_Name: Handle Slide Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &316441678
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 316441677}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2060399380}
+  m_Father: {fileID: 183474488}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &433031335
 GameObject:
   m_ObjectHideFlags: 0
@@ -257,6 +553,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   target: {fileID: 433031339}
+  slider: {fileID: 183474489}
 --- !u!4 &928280436
 Transform:
   m_ObjectHideFlags: 0
@@ -272,6 +569,81 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1633886871
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1633886872}
+  - component: {fileID: 1633886874}
+  - component: {fileID: 1633886873}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1633886872
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1633886871}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2134075221}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 10, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1633886873
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1633886871}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1633886874
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1633886871}
+  m_CullTransparentMesh: 1
 --- !u!1 &1873800725
 GameObject:
   m_ObjectHideFlags: 0
@@ -461,6 +833,192 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2060399379
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2060399380}
+  - component: {fileID: 2060399382}
+  - component: {fileID: 2060399381}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2060399380
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2060399379}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 316441678}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2060399381
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2060399379}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &2060399382
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2060399379}
+  m_CullTransparentMesh: 1
+--- !u!1 &2095547402
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2095547403}
+  - component: {fileID: 2095547405}
+  - component: {fileID: 2095547404}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2095547403
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2095547402}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 183474488}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2095547404
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2095547402}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &2095547405
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2095547402}
+  m_CullTransparentMesh: 1
+--- !u!1 &2134075220
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2134075221}
+  m_Layer: 5
+  m_Name: Fill Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2134075221
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2134075220}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1633886872}
+  m_Father: {fileID: 183474488}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: -5, y: 0}
+  m_SizeDelta: {x: -20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -469,3 +1027,5 @@ SceneRoots:
   - {fileID: 1873800727}
   - {fileID: 928280436}
   - {fileID: 433031339}
+  - {fileID: 284284924}
+  - {fileID: 240099436}


### PR DESCRIPTION
Adds a sequence function that integrates multiple motions.

```cs
var x = 0f;
var y = 0f;

var handle = LSequence.Create()
    .Append(LMotion.Create(0f, 1f, 0.2f).Bind(v => x = v))
    .Append(LMotion.Create(0f, 1f, 0.2f).Bind(v => y = v))
    .Schedule();
```

The entry point for creating a sequence is `LSequence.Create()`, and the sequence is played with `Schedule()`. The return value is `MotionHandle`, just like a normal motion.

Also, LitMotion.Sequences is separated into a separate .asmdef file. Sequences are a powerful feature, but overusing them can lead to unnecessary complexity in your code, so I've made it so that you can add dependencies as needed.