### PR TITLE
Add `WithOnLoopComplete()` and `MotionHandle.ComplatedLoops`

### DIFF
--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/ManagedMotionData.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/ManagedMotionData.cs
@@ -18,6 +18,7 @@ namespace LitMotion
         public object State1;
         public object State2;
         public object UpdateAction;
+        public Action<int> OnLoopCompleteAction;
         public Action OnCompleteAction;
         public Action OnCancelAction;
 
@@ -42,7 +43,7 @@ namespace LitMotion
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void InvokeCancel()
+        public readonly void InvokeOnCancel()
         {
             try
             {
@@ -54,9 +55,30 @@ namespace LitMotion
             }
         }
 
-        public readonly static ManagedMotionData Default = new()
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public readonly void InvokeOnComplete()
         {
-            SkipValuesDuringDelay = true,
-        };
+            try
+            {
+                OnCompleteAction?.Invoke();
+            }
+            catch (Exception ex)
+            {
+                MotionDispatcher.GetUnhandledExceptionHandler()?.Invoke(ex);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public readonly void InvokeOnLoopComplete(int completedLoops)
+        {
+            try
+            {
+                OnLoopCompleteAction?.Invoke(completedLoops);
+            }
+            catch (Exception ex)
+            {
+                MotionDispatcher.GetUnhandledExceptionHandler()?.Invoke(ex);
+            }
+        }
     }
 }

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionData.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionData.cs
@@ -8,11 +8,15 @@ namespace LitMotion
     {
         // state
         public MotionStatus Status;
+        public MotionStatus PrevStatus;
+        public bool IsPreserved;
+        public bool SkipUpdate;
+
+        public ushort ComplpetedLoops;
+        public ushort PrevCompletedLoops;
+
         public double Time;
         public float PlaybackSpeed;
-        public bool IsPreserved;
-        public bool WasStatusChanged;
-        public bool SkipUpdate;
 
         // parameters
         public float Duration;
@@ -27,8 +31,11 @@ namespace LitMotion
         public int Loops;
         public DelayType DelayType;
         public LoopType LoopType;
+
+        public readonly bool WasStatusChanged => Status != PrevStatus;
+        public readonly bool WasLoopCompleted => ComplpetedLoops > PrevCompletedLoops;
     }
-    
+
     /// <summary>
     /// A structure representing motion data.
     /// </summary>

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionHelper.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionHelper.cs
@@ -14,10 +14,9 @@ namespace LitMotion
             where TAdapter : unmanaged, IMotionAdapter<TValue, TOptions>
         {
             var corePtr = (MotionDataCore*)ptr;
-            var prevStatus = corePtr->Status;
 
-            // reset flag(s)
-            corePtr->WasStatusChanged = false;
+            corePtr->PrevCompletedLoops = corePtr->ComplpetedLoops;
+            corePtr->PrevStatus = corePtr->Status;
 
             corePtr->Time = time;
             time = math.max(time, 0.0);
@@ -95,6 +94,8 @@ namespace LitMotion
                 }
             }
 
+            corePtr->ComplpetedLoops = (ushort)clampedCompletedLoops;
+
             float progress;
             switch (corePtr->LoopType)
             {
@@ -128,8 +129,6 @@ namespace LitMotion
             {
                 corePtr->Status = MotionStatus.Playing;
             }
-
-            corePtr->WasStatusChanged = prevStatus != corePtr->Status;
 
             var context = new MotionEvaluationContext()
             {

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionStatus.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionStatus.cs
@@ -3,7 +3,7 @@ namespace LitMotion
     /// <summary>
     /// Motion status.
     /// </summary>
-    public enum MotionStatus
+    public enum MotionStatus : byte
     {
         None = 0,
         Scheduled = 1,

--- a/src/LitMotion/Assets/LitMotion/Runtime/MotionBuilder.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/MotionBuilder.cs
@@ -49,6 +49,7 @@ namespace LitMotion
             buffer.StateCount = default;
 
             buffer.UpdateAction = default;
+            buffer.OnLoopCompleteAction = default;
             buffer.OnCompleteAction = default;
             buffer.OnCancelAction = default;
 
@@ -85,6 +86,7 @@ namespace LitMotion
         public object State2;
         public byte StateCount;
         public object UpdateAction;
+        public Action<int> OnLoopCompleteAction;
         public Action OnCompleteAction;
         public Action OnCancelAction;
         public AnimationCurve AnimationCurve;
@@ -207,6 +209,19 @@ namespace LitMotion
         {
             CheckBuffer();
             buffer.OnCompleteAction += callback;
+            return this;
+        }
+
+        /// <summary>
+        /// Specify a callback to be performed when each loop finishes.
+        /// </summary>
+        /// <param name="callback">Callback to be performed when each loop finishes.</param>
+        /// <returns>This builder to allow chaining multiple method calls.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public readonly MotionBuilder<TValue, TOptions, TAdapter> WithOnLoopComplete(Action<int> callback)
+        {
+            CheckBuffer();
+            buffer.OnLoopCompleteAction += callback;
             return this;
         }
 
@@ -456,7 +471,7 @@ namespace LitMotion
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         readonly void CheckBuffer()
         {
-            if (buffer == null || buffer.Version != version) throw new InvalidOperationException("MotionBuilder is either not initialized or has already run a Build (or Bind). If you want to build or bind multiple times, call Preseve() for MotionBuilder.");
+            if (buffer == null || buffer.Version != version) throw new InvalidOperationException("MotionBuilder is either not initialized or has already run a Build (or Bind).");
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/LitMotion/Assets/LitMotion/Runtime/MotionHandle.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/MotionHandle.cs
@@ -49,6 +49,17 @@ namespace LitMotion
         }
 
         /// <summary>
+        /// The number of loops completed
+        /// </summary>
+        public readonly int ComplatedLoops
+        {
+            get
+            {
+                return MotionManager.GetDataRef(this).ComplpetedLoops;
+            }
+        }
+
+        /// <summary>
         /// Motion playback speed.
         /// </summary>
         public readonly float PlaybackSpeed

--- a/src/LitMotion/Assets/LitMotion/Tests/Runtime/CallbackTest.cs
+++ b/src/LitMotion/Assets/LitMotion/Tests/Runtime/CallbackTest.cs
@@ -47,7 +47,6 @@ namespace LitMotion.Tests.Runtime
             Assert.That(loopCount, Is.EqualTo(3));
         }
 
-
         [UnityTest]
         public IEnumerator Test_CreateOnCallback()
         {

--- a/src/LitMotion/Assets/LitMotion/Tests/Runtime/CallbackTest.cs
+++ b/src/LitMotion/Assets/LitMotion/Tests/Runtime/CallbackTest.cs
@@ -32,6 +32,23 @@ namespace LitMotion.Tests.Runtime
         }
 
         [UnityTest]
+        public IEnumerator Test_OnLoopComplete()
+        {
+            var loopCount = 0;
+            LMotion.Create(0f, 10f, 1f)
+                .WithLoops(3)
+                .WithOnLoopComplete(x => loopCount = x)
+                .RunWithoutBinding();
+            yield return new WaitForSeconds(1f);
+            Assert.That(loopCount, Is.EqualTo(1));
+            yield return new WaitForSeconds(1f);
+            Assert.That(loopCount, Is.EqualTo(2));
+            yield return new WaitForSeconds(1f);
+            Assert.That(loopCount, Is.EqualTo(3));
+        }
+
+
+        [UnityTest]
         public IEnumerator Test_CreateOnCallback()
         {
             var created = false;

--- a/src/LitMotion/Assets/LitMotion/Tests/Runtime/MotionHandleTest.cs
+++ b/src/LitMotion/Assets/LitMotion/Tests/Runtime/MotionHandleTest.cs
@@ -1,7 +1,9 @@
 using System.Collections;
+using NUnit.Framework;
 using UnityEngine;
-using UnityEngine.Assertions;
+using UnityEngine.Assertions.Comparers;
 using UnityEngine.TestTools;
+using UnityEngine.TestTools.Utils;
 
 namespace LitMotion.Tests.Runtime
 {
@@ -60,7 +62,7 @@ namespace LitMotion.Tests.Runtime
                 });
             yield return new WaitForSeconds(1f);
             handle.Complete();
-            Assert.AreApproximatelyEqual(value, endValue);
+            Assert.That(value, Is.EqualTo(endValue).Using(FloatEqualityComparer.Instance));
             Assert.IsTrue(!handle.IsActive());
         }
 
@@ -78,7 +80,7 @@ namespace LitMotion.Tests.Runtime
             yield return new WaitForSeconds(1f);
             var tryResult = handle.TryComplete();
             Assert.IsTrue(tryResult);
-            Assert.AreApproximatelyEqual(value, endValue);
+            Assert.That(value, Is.EqualTo(endValue).Using(FloatEqualityComparer.Instance));
             Assert.IsTrue(!handle.IsActive());
 
             tryResult = handle.TryComplete();
@@ -99,7 +101,7 @@ namespace LitMotion.Tests.Runtime
                 });
             yield return new WaitForSeconds(1f);
             handle.Complete();
-            Assert.AreApproximatelyEqual(value, startValue);
+            Assert.That(value, Is.EqualTo(startValue).Using(FloatEqualityComparer.Instance));
             Assert.IsTrue(!handle.IsActive());
         }
 
@@ -147,6 +149,22 @@ namespace LitMotion.Tests.Runtime
             Assert.IsTrue(handle.IsActive());
             yield return new WaitForSeconds(2.5f);
             Assert.IsFalse(handle.IsActive());
+        }
+
+        [UnityTest]
+        public IEnumerator Test_CompletedLoops()
+        {
+            var handle = LMotion.Create(0f, 10f, 1f)
+                .WithLoops(3)
+                .RunWithoutBinding();
+
+            Assert.That(handle.ComplatedLoops, Is.EqualTo(0));
+            yield return new WaitForSeconds(1f);
+            Assert.That(handle.ComplatedLoops, Is.EqualTo(1));
+            yield return new WaitForSeconds(1f);
+            Assert.That(handle.ComplatedLoops, Is.EqualTo(2));
+            yield return new WaitForSeconds(1f);
+            Assert.That(handle.ComplatedLoops, Is.EqualTo(3));
         }
     }
 }


### PR DESCRIPTION
Related to #131, this adds `WithOnLoopComplete()` which adds a callback at the end of each loop. Also add a `ComplatedLoops` property to get the number of completed loops from the MotionHandle.


## Example 

```cs
var loopCount = 0;

LMotion.Create(0f, 10f, 1f)
    .WithLoops(3)
    .WithOnLoopComplete(x => loopCount = x)
    .RunWithoutBinding();

yield return new WaitForSeconds(1f);
Assert.That(loopCount, Is.EqualTo(1));

yield return new WaitForSeconds(1f);
Assert.That(loopCount, Is.EqualTo(2));

yield return new WaitForSeconds(1f);
Assert.That(loopCount, Is.EqualTo(3));
```