### PR TITLE
Add check if motion is in sequence

### DIFF
--- a/src/LitMotion/Assets/LitMotion/Editor/MotionDebuggerWindow.cs
+++ b/src/LitMotion/Assets/LitMotion/Editor/MotionDebuggerWindow.cs
@@ -147,8 +147,8 @@ namespace LitMotion.Editor
                 var selected = treeView.state.selectedIDs;
                 if (selected.Count > 0 && treeView.CurrentBindingItems.FirstOrDefault(x => x.id == selected[0]) is MotionDebuggerViewItem item)
                 {
-                    ref var unmanagedData = ref MotionManager.GetDataRef(item.Handle);
-                    ref var managedData = ref MotionManager.GetManagedDataRef(item.Handle);
+                    ref var unmanagedData = ref MotionManager.GetDataRef(item.Handle, MotionStoragePermission.Admin);
+                    ref var managedData = ref MotionManager.GetManagedDataRef(item.Handle, MotionStoragePermission.Admin);
                     var debugInfo = MotionManager.GetDebugInfo(item.Handle);
 
                     using (new EditorGUILayout.VerticalScope(GUI.skin.box))

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/Error.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/Error.cs
@@ -35,5 +35,10 @@ namespace LitMotion
         {
             throw new InvalidOperationException("Motion has already been canceled or completed.");
         }
+
+        public static void MotionIsInSequence()
+        {
+            throw new InvalidOperationException("Cannot access the motion in sequence.");
+        }
     }
 }

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionData.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionData.cs
@@ -10,7 +10,7 @@ namespace LitMotion
         public MotionStatus Status;
         public MotionStatus PrevStatus;
         public bool IsPreserved;
-        public bool SkipUpdate;
+        public bool IsInSequence;
 
         public ushort ComplpetedLoops;
         public ushort PrevCompletedLoops;

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionManager.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionManager.cs
@@ -20,17 +20,17 @@ namespace LitMotion
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ref MotionDataCore GetDataRef(MotionHandle handle)
+        public static ref MotionDataCore GetDataRef(MotionHandle handle, MotionStoragePermission permission)
         {
             CheckTypeId(handle);
-            return ref list[handle.StorageId].GetDataRef(handle);
+            return ref list[handle.StorageId].GetDataRef(handle, permission);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ref ManagedMotionData GetManagedDataRef(MotionHandle handle)
+        public static ref ManagedMotionData GetManagedDataRef(MotionHandle handle, MotionStoragePermission permission)
         {
             CheckTypeId(handle);
-            return ref list[handle.StorageId].GetManagedDataRef(handle);
+            return ref list[handle.StorageId].GetManagedDataRef(handle, permission);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -41,31 +41,31 @@ namespace LitMotion
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Complete(MotionHandle handle)
+        public static void Complete(MotionHandle handle, MotionStoragePermission permission)
         {
             CheckTypeId(handle);
-            list[handle.StorageId].Complete(handle);
+            list[handle.StorageId].Complete(handle, permission);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryComplete(MotionHandle handle)
+        public static bool TryComplete(MotionHandle handle, MotionStoragePermission permission)
         {
             CheckTypeId(handle);
-            return list[handle.StorageId].TryComplete(handle);
+            return list[handle.StorageId].TryComplete(handle, permission);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Cancel(MotionHandle handle)
+        public static void Cancel(MotionHandle handle, MotionStoragePermission permission)
         {
             CheckTypeId(handle);
-            list[handle.StorageId].Cancel(handle);
+            list[handle.StorageId].Cancel(handle, permission);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryCancel(MotionHandle handle)
+        public static bool TryCancel(MotionHandle handle, MotionStoragePermission permission)
         {
             CheckTypeId(handle);
-            return list[handle.StorageId].TryCancel(handle);
+            return list[handle.StorageId].TryCancel(handle, permission);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -76,10 +76,10 @@ namespace LitMotion
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void SetTime(MotionHandle handle, double time)
+        public static void SetTime(MotionHandle handle, double time, MotionStoragePermission permission)
         {
             CheckTypeId(handle);
-            list[handle.StorageId].SetTime(handle, time);
+            list[handle.StorageId].SetTime(handle, time, permission);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionManager.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionManager.cs
@@ -83,10 +83,10 @@ namespace LitMotion
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void AddToSequence(ref MotionHandle handle, out double motionDuration)
+        public static void AddToSequence(MotionHandle handle, out double motionDuration)
         {
             CheckTypeId(handle);
-            list[handle.StorageId].AddToSequence(ref handle, out motionDuration);
+            list[handle.StorageId].AddToSequence(handle, out motionDuration);
         }
 
         // For MotionTracker

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionStorage.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionStorage.cs
@@ -430,7 +430,7 @@ namespace LitMotion
             }
 
             dataRef.Core.IsPreserved = true;
-            dataRef.Core.SkipUpdate = true;
+            dataRef.Core.IsInSequence = true;
 
             // ref var managedDataRef = ref managedDataArray[slot.DenseIndex];
             // managedDataRef.SkipValuesDuringDelay = true;

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionStorage.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionStorage.cs
@@ -42,7 +42,7 @@ namespace LitMotion
         void SetTime(MotionHandle handle, double time, MotionStoragePermission permission);
         ref MotionDataCore GetDataRef(MotionHandle handle, MotionStoragePermission permission);
         ref ManagedMotionData GetManagedDataRef(MotionHandle handle, MotionStoragePermission permission);
-        void AddToSequence(ref MotionHandle handle, out double motionDuration);
+        void AddToSequence(MotionHandle handle, out double motionDuration);
         MotionDebugInfo GetDebugInfo(MotionHandle handle);
         void Reset();
     }
@@ -446,7 +446,7 @@ namespace LitMotion
             }
         }
 
-        public void AddToSequence(ref MotionHandle handle, out double motionDuration)
+        public void AddToSequence(MotionHandle handle, out double motionDuration)
         {
             ref var slot = ref GetSlotWithVarify(handle, MotionStoragePermission.Admin);
             ref var dataRef = ref unmanagedDataArray[slot.DenseIndex];

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/Tasks/MotionConfiguredSourceBase.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/Tasks/MotionConfiguredSourceBase.cs
@@ -74,7 +74,7 @@ namespace LitMotion
             this.cancelAwaitOnMotionCanceled = cancelAwaitOnMotionCanceled;
             this.cancellationToken = cancellationToken;
 
-            ref var managedData = ref MotionManager.GetManagedDataRef(motionHandle);
+            ref var managedData = ref MotionManager.GetManagedDataRef(motionHandle, MotionStoragePermission.Admin);
             originalCancelAction = managedData.OnCancelAction;
             originalCompleteAction = managedData.OnCompleteAction;
             managedData.OnCancelAction = onCancelCallbackDelegate;
@@ -129,7 +129,7 @@ namespace LitMotion
         {
             if (checkIsActive && !motionHandle.IsActive()) return;
 
-            ref var managedData = ref MotionManager.GetManagedDataRef(motionHandle);
+            ref var managedData = ref MotionManager.GetManagedDataRef(motionHandle, MotionStoragePermission.Admin);
             managedData.OnCancelAction = originalCancelAction;
             managedData.OnCompleteAction = originalCompleteAction;
         }

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/UpdateRunner.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/UpdateRunner.cs
@@ -64,7 +64,7 @@ namespace LitMotion
                 {
                     var currentDataPtr = dataPtr + i;
 
-                    if (currentDataPtr->Core.SkipUpdate) continue;
+                    if (currentDataPtr->Core.IsInSequence) continue;
 
                     var status = currentDataPtr->Core.Status;
                     ref var managedData = ref managedDataSpan[i];

--- a/src/LitMotion/Assets/LitMotion/Runtime/MotionAwaiter.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/MotionAwaiter.cs
@@ -31,7 +31,7 @@ namespace LitMotion
         {
             if (continuation == null) return;
 
-            ref var managedData = ref MotionManager.GetManagedDataRef(handle);
+            ref var managedData = ref MotionManager.GetManagedDataRef(handle, MotionStoragePermission.Admin);
             managedData.OnCompleteAction += continuation;
             managedData.OnCancelAction += continuation;
         }

--- a/src/LitMotion/Assets/LitMotion/Runtime/MotionDebugger.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/MotionDebugger.cs
@@ -27,7 +27,7 @@ namespace LitMotion
 
             if (EnableStackTrace) state.StackTrace = new StackTrace(skipFrames, true);
 
-            ref var managedData = ref MotionManager.GetManagedDataRef(motionHandle);
+            ref var managedData = ref MotionManager.GetManagedDataRef(motionHandle, MotionStoragePermission.Admin);
             state.OriginalOnCompleteCallback = managedData.OnCompleteAction;
             managedData.OnCompleteAction = state.OnCompleteDelegate;
             state.OriginalOnCancelCallback = managedData.OnCancelAction;
@@ -84,7 +84,7 @@ namespace LitMotion
                     MotionDispatcher.GetUnhandledExceptionHandler()?.Invoke(ex);
                 }
 
-                if (Handle.IsActive() && !MotionManager.GetDataRef(Handle).IsPreserved)
+                if (Handle.IsActive() && !MotionManager.GetDataRef(Handle, MotionStoragePermission.Admin).IsPreserved)
                 {
                     Release();
                 }

--- a/src/LitMotion/Assets/LitMotion/Runtime/MotionHandle.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/MotionHandle.cs
@@ -29,11 +29,11 @@ namespace LitMotion
         {
             get
             {
-                return MotionManager.GetDataRef(this).Time;
+                return MotionManager.GetDataRef(this, MotionStoragePermission.Admin).Time;
             }
             set
             {
-                MotionManager.SetTime(this, value);
+                MotionManager.SetTime(this, value, MotionStoragePermission.User);
             }
         }
 
@@ -44,7 +44,7 @@ namespace LitMotion
         {
             get
             {
-                return MotionHelper.GetTotalDuration(ref MotionManager.GetDataRef(this));
+                return MotionHelper.GetTotalDuration(ref MotionManager.GetDataRef(this, MotionStoragePermission.Admin));
             }
         }
 
@@ -55,7 +55,7 @@ namespace LitMotion
         {
             get
             {
-                return MotionManager.GetDataRef(this).ComplpetedLoops;
+                return MotionManager.GetDataRef(this, MotionStoragePermission.User).ComplpetedLoops;
             }
         }
 
@@ -66,11 +66,11 @@ namespace LitMotion
         {
             get
             {
-                return MotionManager.GetDataRef(this).PlaybackSpeed;
+                return MotionManager.GetDataRef(this, MotionStoragePermission.User).PlaybackSpeed;
             }
             set
             {
-                MotionManager.GetDataRef(this).PlaybackSpeed = value;
+                MotionManager.GetDataRef(this, MotionStoragePermission.User).PlaybackSpeed = value;
             }
         }
 

--- a/src/LitMotion/Assets/LitMotion/Runtime/MotionHandleExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/MotionHandleExtensions.cs
@@ -36,7 +36,7 @@ namespace LitMotion
         public static string GetDebugName(this MotionHandle handle)
         {
 #if LITMOTION_DEBUG
-            return MotionManager.GetManagedDataRef(handle).DebugName ?? handle.ToString();
+            return MotionManager.GetManagedDataRef(handle, MotionStoragePermission.Admin).DebugName ?? handle.ToString();
 #else
             return handle.ToString();
 #endif
@@ -50,10 +50,10 @@ namespace LitMotion
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static MotionHandle Preserve(this MotionHandle handle)
         {
-            MotionManager.GetDataRef(handle).IsPreserved = true;
+            MotionManager.GetDataRef(handle, MotionStoragePermission.User).IsPreserved = true;
             return handle;
         }
-    
+
         /// <summary>
         /// Complete motion.
         /// </summary>
@@ -61,7 +61,7 @@ namespace LitMotion
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Complete(this MotionHandle handle)
         {
-            MotionManager.Complete(handle);
+            MotionManager.Complete(handle, MotionStoragePermission.User);
         }
 
         /// <summary>
@@ -72,7 +72,7 @@ namespace LitMotion
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryComplete(this MotionHandle handle)
         {
-            return MotionManager.TryComplete(handle);
+            return MotionManager.TryComplete(handle, MotionStoragePermission.User);
         }
 
         /// <summary>
@@ -82,7 +82,7 @@ namespace LitMotion
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Cancel(this MotionHandle handle)
         {
-            MotionManager.Cancel(handle);
+            MotionManager.Cancel(handle, MotionStoragePermission.User);
         }
 
         /// <summary>
@@ -93,7 +93,7 @@ namespace LitMotion
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryCancel(this MotionHandle handle)
         {
-            return MotionManager.TryCancel(handle);
+            return MotionManager.TryCancel(handle, MotionStoragePermission.User);
         }
 
         /// <summary>

--- a/src/LitMotion/Assets/LitMotion/Runtime/MotionUpdateJob.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/MotionUpdateJob.cs
@@ -35,7 +35,7 @@ namespace LitMotion
             if (Hint.Likely(corePtr->Status is MotionStatus.Scheduled or MotionStatus.Delayed or MotionStatus.Playing) ||
                 Hint.Unlikely(corePtr->IsPreserved && corePtr->Status is MotionStatus.Completed))
             {
-                if (Hint.Unlikely(corePtr->SkipUpdate)) return;
+                if (Hint.Unlikely(corePtr->IsInSequence)) return;
 
                 var deltaTime = corePtr->TimeKind switch
                 {

--- a/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceBuilder.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceBuilder.cs
@@ -45,7 +45,7 @@ namespace LitMotion.Sequences
 
         public void Append(MotionHandle handle)
         {
-            MotionManager.AddToSequence(ref handle, out var motionDuration);
+            MotionManager.AddToSequence(handle, out var motionDuration);
             AddItem(new MotionSequenceItem(tail, handle));
             AppendInterval(motionDuration);
         }
@@ -59,7 +59,7 @@ namespace LitMotion.Sequences
 
         public void Insert(double position, MotionHandle handle)
         {
-            MotionManager.AddToSequence(ref handle, out var motionDuration);
+            MotionManager.AddToSequence(handle, out var motionDuration);
             AddItem(new MotionSequenceItem(position, handle));
             duration = Math.Max(duration, position + motionDuration);
         }

--- a/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceSource.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Sequences/MotionSequenceSource.cs
@@ -85,13 +85,13 @@ namespace LitMotion.Sequences
                 {
                     var item = span[index];
                     if (item.Position < time) break;
-                    item.Handle.Time = time - item.Position;
+                    MotionManager.SetTime(item.Handle, time - item.Position, MotionStoragePermission.Admin);
                     index--;
                 }
 
                 foreach (var item in span[..(index + 1)])
                 {
-                    item.Handle.Time = time - item.Position;
+                    MotionManager.SetTime(item.Handle, time - item.Position, MotionStoragePermission.Admin);
                 }
             }
         }
@@ -101,7 +101,7 @@ namespace LitMotion.Sequences
         void OnComplete()
         {
             if (!handle.IsActive()) return;
-            if (MotionManager.GetDataRef(handle).IsPreserved) return;
+            if (MotionManager.GetDataRef(handle, MotionStoragePermission.Admin).IsPreserved) return;
 
             Return(this);
         }
@@ -110,7 +110,7 @@ namespace LitMotion.Sequences
         {
             foreach (var item in Items)
             {
-                item.Handle.Cancel();
+                MotionManager.Cancel(item.Handle, MotionStoragePermission.Admin);
             }
 
             Return(this);

--- a/src/LitMotion/Assets/LitMotion/Tests/Runtime/MotionHandleTest.cs
+++ b/src/LitMotion/Assets/LitMotion/Tests/Runtime/MotionHandleTest.cs
@@ -156,7 +156,8 @@ namespace LitMotion.Tests.Runtime
         {
             var handle = LMotion.Create(0f, 10f, 1f)
                 .WithLoops(3)
-                .RunWithoutBinding();
+                .RunWithoutBinding()
+                .Preserve();
 
             Assert.That(handle.ComplatedLoops, Is.EqualTo(0));
             yield return new WaitForSeconds(1f);

--- a/src/LitMotion/Assets/LitMotion/Tests/Runtime/SequenceTest.cs
+++ b/src/LitMotion/Assets/LitMotion/Tests/Runtime/SequenceTest.cs
@@ -182,7 +182,17 @@ namespace LitMotion.Tests.Runtime
             Assert.Throws<InvalidOperationException>(() =>
             {
                 handle.Complete();
-            });
+            }, "Cannot access the motion in sequence.");
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                handle.Cancel();
+            }, "Cannot access the motion in sequence.");
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                handle.Time = 0;
+            }, "Cannot access the motion in sequence.");
         }
     }
 }


### PR DESCRIPTION
Previously, when a motion was added to a sequence, the handle was invalidated by incrementing the version. This prevented the internal motion from being accidentally manipulated, but it caused problems such as the debugger being unable to track it because the previous handle was invalid.

Instead, I added a process to check whether all operations are for motions within a sequence and make them inaccessible to the user. This allows us to display an appropriate error without having to manipulate the handle version.