### PR TITLE
Bugfix: Endless exception loop when exiting prefab mode

### DIFF
--- a/src/LitMotion/Assets/LitMotion.Animation/Editor/LitMotionAnimationEditor.cs
+++ b/src/LitMotion/Assets/LitMotion.Animation/Editor/LitMotionAnimationEditor.cs
@@ -3,6 +3,7 @@ using UnityEditor;
 using UnityEditor.UIElements;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEditor.SceneManagement;
 
 namespace LitMotion.Animation.Editor
 {
@@ -192,7 +193,10 @@ namespace LitMotion.Animation.Editor
                     flexGrow = 1f,
                 }
             };
-            var playButton = new Button(() => ((LitMotionAnimation)target).Play())
+            var playButton = new Button(() => {
+				((LitMotionAnimation)target).Play();
+				PrefabStage.prefabStageClosing += OnPrefabStageClosing;
+			})
             {
                 text = "Play",
                 style = {
@@ -345,5 +349,14 @@ namespace LitMotion.Animation.Editor
         {
             return !((LitMotionAnimation)target).IsActive;
         }
+
+		void OnPrefabStageClosing(PrefabStage stage)
+		{
+			PrefabStage.prefabStageClosing -= OnPrefabStageClosing;
+			foreach (var  i in stage.prefabContentsRoot.GetComponentsInChildren<LitMotionAnimation>(true))
+			{
+				i.Stop();
+			}
+		}
     }
 }

--- a/src/LitMotion/Assets/LitMotion.Animation/Editor/LitMotionAnimationEditor.cs
+++ b/src/LitMotion/Assets/LitMotion.Animation/Editor/LitMotionAnimationEditor.cs
@@ -194,9 +194,13 @@ namespace LitMotion.Animation.Editor
                 }
             };
             var playButton = new Button(() => {
-				((LitMotionAnimation)target).Play();
-				PrefabStage.prefabStageClosing += OnPrefabStageClosing;
-			})
+                ((LitMotionAnimation)target).Play();
+                if (PrefabStageUtility.GetCurrentPrefabStage() != null)
+                {
+                    PrefabStage.prefabStageClosing -= OnPrefabStageClosing;
+                    PrefabStage.prefabStageClosing += OnPrefabStageClosing;
+                }
+            })
             {
                 text = "Play",
                 style = {
@@ -350,13 +354,13 @@ namespace LitMotion.Animation.Editor
             return !((LitMotionAnimation)target).IsActive;
         }
 
-		void OnPrefabStageClosing(PrefabStage stage)
-		{
-			PrefabStage.prefabStageClosing -= OnPrefabStageClosing;
-			foreach (var  i in stage.prefabContentsRoot.GetComponentsInChildren<LitMotionAnimation>(true))
-			{
-				i.Stop();
-			}
-		}
+        void OnPrefabStageClosing(PrefabStage stage)
+        {
+            PrefabStage.prefabStageClosing -= OnPrefabStageClosing;
+            foreach (var  i in stage.prefabContentsRoot.GetComponentsInChildren<LitMotionAnimation>(true))
+            {
+                i.Stop();
+            }
+        }
     }
 }


### PR DESCRIPTION
プレハブモード中に、LitMotionAnimationコンポーネントのPlayを押し、Stopを押さずにプレハブモードを抜けるとUnityエディタを再起動しない限りコンソールにMissingRefrenceExceptionが出続けます。