### PR TITLE
feat: add Unset enum to Ease to match DOTween

### DIFF
--- a/src/LitMotion/Assets/LitMotion/Runtime/Ease.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Ease.cs
@@ -5,7 +5,7 @@ namespace LitMotion
     /// </summary>
     public enum Ease
     {
-        UnSet,
+        Unset,
         Linear,
         InSine,
         OutSine,

--- a/src/LitMotion/Assets/LitMotion/Runtime/Ease.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Ease.cs
@@ -5,6 +5,7 @@ namespace LitMotion
     /// </summary>
     public enum Ease
     {
+        UnSet,
         Linear,
         InSine,
         OutSine,


### PR DESCRIPTION
Adds UnSet as the first element in the Ease enum. This aligns the enum's indexing with the DOTween Ease enum type, ensuring consistent behavior and compatibility.