### PR TITLE
Fixing LitMotion to work with Enter the Play Mode

### DIFF
--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/EnterThePlayModeHelper.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/EnterThePlayModeHelper.cs
@@ -18,7 +18,6 @@ namespace LitMotion.LitMotion.Runtime.Internal
         {
             foreach (var action in _scheduledActions)
                 action();
-            _scheduledActions.Clear();
             MotionDispatcher.Clear();
         }
 #endif

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/EnterThePlayModeHelper.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/EnterThePlayModeHelper.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+namespace LitMotion.LitMotion.Runtime.Internal
+{
+    internal class EnterThePlayModeHelper
+    {
+#if UNITY_EDITOR
+        private static readonly List<Action> _scheduledActions = new();
+
+        [InitializeOnEnterPlayMode]
+        private static void Reset()
+        {
+            foreach (var action in _scheduledActions)
+                action();
+            _scheduledActions.Clear();
+            MotionDispatcher.Clear();
+        }
+#endif
+        
+        [Conditional("UNITY_EDITOR")]
+        public static void Register<TValue, TOptions, TAdapter>(MotionStorage<TValue, TOptions, TAdapter> storage)
+            where TValue : unmanaged
+            where TOptions : unmanaged, IMotionOptions
+            where TAdapter : unmanaged, IMotionAdapter<TValue, TOptions>
+        {
+#if UNITY_EDITOR
+            if (EditorSettings.enterPlayModeOptionsEnabled)
+                _scheduledActions.Add(storage.Reset);
+#endif
+        }
+        
+        [Conditional("UNITY_EDITOR")]
+        public static void Register<TValue, TOptions, TAdapter>(UpdateRunner<TValue, TOptions, TAdapter> runner)
+            where TValue : unmanaged
+            where TOptions : unmanaged, IMotionOptions
+            where TAdapter : unmanaged, IMotionAdapter<TValue, TOptions>
+        {
+#if UNITY_EDITOR
+            if (EditorSettings.enterPlayModeOptionsEnabled)
+                _scheduledActions.Add(runner.Reset);
+#endif
+        }
+    }
+}

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/EnterThePlayModeHelper.cs.meta
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/EnterThePlayModeHelper.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a81228c84a2b49cda1bea548b9bf0867
+timeCreated: 1753999485

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionManager.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionManager.cs
@@ -115,5 +115,14 @@ namespace LitMotion
                 throw new ArgumentException("Invalid type id.");
             }
         }
+
+#if UNITY_EDITOR
+        [UnityEditor.InitializeOnEnterPlayMode]
+        private static void Clear()
+        {
+            MotionTypeCount = 0;
+            list.Clear();
+        }
+#endif
     }
 }

--- a/src/LitMotion/Assets/LitMotion/Runtime/MotionDispatcher.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/MotionDispatcher.cs
@@ -2,6 +2,7 @@ using System;
 using System.Runtime.CompilerServices;
 using UnityEngine;
 using LitMotion.Collections;
+using LitMotion.LitMotion.Runtime.Internal;
 
 #if UNITY_EDITOR
 using UnityEditor;
@@ -51,6 +52,7 @@ namespace LitMotion
                 {
                     storage = new MotionStorage<TValue, TOptions, TAdapter>(MotionManager.MotionTypeCount);
                     MotionManager.Register(storage);
+                    EnterThePlayModeHelper.Register(storage);
                 }
                 return storage;
             }
@@ -100,6 +102,7 @@ namespace LitMotion
                         runner = new UpdateRunner<TValue, TOptions, TAdapter>(storage, Time.timeAsDouble, Time.unscaledTimeAsDouble, Time.realtimeSinceStartupAsDouble);
                     }
                     GetRunnerList(playerLoopTiming).Add(runner);
+                    EnterThePlayModeHelper.Register(runner);
                     return (runner, true);
                 }
                 return (runner, false);
@@ -251,6 +254,7 @@ namespace LitMotion
                 {
                     storage = new MotionStorage<TValue, TOptions, TAdapter>(MotionManager.MotionTypeCount);
                     MotionManager.Register(storage);
+                    EnterThePlayModeHelper.Register(storage);
                 }
                 return storage;
             }


### PR DESCRIPTION
Fixes #239 

When using enter the play mode options, unity doesn't perform a domain reload. Which means the static fields will not be reset automatically.

I added the necessary callbacks to reset all the important static fields to make sure LitMotion works without a domain reload.