### PR TITLE
Add AutoPlayMode enum to enhance animation playback control

### DIFF
--- a/src/LitMotion/Assets/LitMotion.Animation/Editor/LitMotionAnimationEditor.cs
+++ b/src/LitMotion/Assets/LitMotion.Animation/Editor/LitMotionAnimationEditor.cs
@@ -93,7 +93,7 @@ namespace LitMotion.Animation.Editor
         VisualElement CreateSettingsPanel()
         {
             var box = CreateBox("Settings");
-            box.Add(new PropertyField(serializedObject.FindProperty("playOnAwake")));
+            box.Add(new PropertyField(serializedObject.FindProperty("autoPlayMode")));
             box.Add(new PropertyField(serializedObject.FindProperty("animationMode")));
             return box;
         }


### PR DESCRIPTION
This PR introduces a new AutoPlayMode enum to provide more flexible control over automatic animation playback in LitMotionAnimation.

The existing bool playOnAwake field has been replaced with AutoPlayMode autoPlayMode, allowing the animation to play either once on the first activation or every time the object is enabled.



✨ Key Changes

- Added AutoPlayMode enum (OnceOnEnable, EveryEnable)
- Replaced playOnAwake with autoPlayMode in LitMotionAnimation
- Implemented ISerializationCallbackReceiver to migrate existing serialized playOnAwake data to the new autoPlayMode field
- Updated corresponding editor script LitMotionAnimationEditor.cs to reflect new enum in the inspector



🎯 Purpose

Previously, the animation played only once when the object was first enabled. With this update, developers can choose to replay the animation every time the object becomes active, enhancing flexibility for dynamic UI or object behaviors.