### PR TITLE
[LitMotionAnimation] Fixed dropdown list style breaking issue

### DIFF
--- a/src/LitMotion/Assets/LitMotion.Animation/Editor/LitMotionAnimationEditor.cs
+++ b/src/LitMotion/Assets/LitMotion.Animation/Editor/LitMotionAnimationEditor.cs
@@ -128,7 +128,11 @@ namespace LitMotion.Animation.Editor
                     alignSelf = Align.Center
                 }
             };
-            addButton.clicked += () => dropdown.Show(addButton.worldBound);
+            addButton.clicked += () =>
+            {
+                GUI.skin = EditorGUIUtility.GetBuiltinSkin(EditorSkin.Scene);
+                dropdown.Show(addButton.worldBound);
+            };
             box.Add(addButton);
 
             box.schedule.Execute(() =>


### PR DESCRIPTION
プロジェクト固有の問題の可能性もありますが・・・カスタムクラスをコンパイルしAdd...ボタンを押すとレイアウトが崩れます。
<img width="191" height="207" alt="image" src="https://github.com/user-attachments/assets/eac78c33-44cb-4068-9508-0662f5428a0a" />
GUI.skinにGameSkinになるとAdvancedDropDownが参照しているstyleが見つからないのが原因らしく以下のようなwarningがいくつかでます。
```
(Filename: ./Library/PackageCache/com.annulusgames.lit-motion.animation@5de1ade9ebe8/Editor/LitMotionAnimationEditor.cs Line: 150)
Unable to find style 'DD HeaderStyle' in skin 'GameSkin' mouseUp
```
そこで強制的にGUI.skinを更新することにより解決しました。
