### PR TITLE
Fix sequence hold handle

### DIFF
--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionManager.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionManager.cs
@@ -69,6 +69,13 @@ namespace LitMotion
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsValid(MotionHandle handle)
+        {
+            if (handle.StorageId < 0 || handle.StorageId >= MotionTypeCount) return false;
+            return list[handle.StorageId].IsValid(handle);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsActive(MotionHandle handle)
         {
             if (handle.StorageId < 0 || handle.StorageId >= MotionTypeCount) return false;

--- a/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionStorage.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Internal/MotionStorage.cs
@@ -19,6 +19,7 @@ namespace LitMotion
 
     internal interface IMotionStorage
     {
+        bool IsValid(MotionHandle handle);
         bool IsActive(MotionHandle handle);
         bool IsPlaying(MotionHandle handle);
         bool TryCancel(MotionHandle handle, bool checkIsInSequence = true);
@@ -210,6 +211,15 @@ namespace LitMotion
             {
                 RemoveAt(sparseSetCore.GetSlotRefUnchecked(list[i].Index).DenseIndex);
             }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool IsValid(MotionHandle handle)
+        {
+            ref var slot = ref sparseSetCore.GetSlotRefUnchecked(handle.Index);
+            if (IsDenseIndexOutOfRange(slot.DenseIndex)) return false;
+            if (IsInvalidVersion(slot.Version, handle)) return false;
+            return true;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -428,7 +438,7 @@ namespace LitMotion
                 throw new ArgumentException("Cannot add an infinitely looping motion to a sequence.");
             }
 
-            dataRef.Core.State.IsPreserved = false;
+            dataRef.Core.State.IsPreserved = true;
             dataRef.Core.State.IsInSequence = true;
         }
 

--- a/src/LitMotion/Assets/LitMotion/Runtime/MotionHandleExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/MotionHandleExtensions.cs
@@ -17,6 +17,17 @@ namespace LitMotion
     public static class MotionHandleExtensions
     {
         /// <summary>
+        /// Checks if a motion is valid.
+        /// </summary>
+        /// <param name="handle">This motion handle</param>
+        /// <returns>True if motion is valid, otherwise false.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsValid(this MotionHandle handle)
+        {
+            return MotionManager.IsValid(handle);
+        }
+
+        /// <summary>
         /// Checks if a motion is active.
         /// </summary>
         /// <param name="handle">This motion handle</param>

--- a/src/LitMotion/Assets/LitMotion/Runtime/MotionSequenceSource.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/MotionSequenceSource.cs
@@ -108,8 +108,13 @@ namespace LitMotion
 
         void OnComplete()
         {
-            if (!handle.IsActive()) return;
+            if (!handle.IsValid()) return;
             if (MotionManager.GetDataRef(handle, false).State.IsPreserved) return;
+
+            foreach (var item in Items)
+            {
+                MotionManager.Cancel(item.Handle, false);
+            }
 
             Return(this);
         }


### PR DESCRIPTION
# Issue1 : early return
The `OnComplete` method of the Sequence contained an early return statement: `if (!handle.IsActive()) return;`. However, since `OnComplete` is always called after the State transitions to Complete, the early return clause was always executed.

# Issue2 : Preserved handle
Additionally, when adding a handle to the sequence, the Preserve flag was automatically set.
As a result, handles remained in memory even after the sequence execution completed.

# Resolution1 : early return
I added an `IsValid` method that checks only whether the handle's version is appropriate and whether the handle exists in storage, without referencing the state.
The early return clause in `Sequence.OnComplete` was replaced with this `IsValid` check.

# Resolution2 : Preserved handle
Additionally, upon the sequence's overall completion, we modified the behavior to cancel all handles within the sequence and discard preserved handles.

# Verification
Verified execution using a combination of Join/Append/AppendInterval.
The debug screen results at the time of Motion completion are as follows.

| before | after |
| --- | --- |
| <img width="805" height="691" alt="image" src="https://github.com/user-attachments/assets/83077c94-1b14-4a9d-8a71-ff03107a43b5" /> | <img width="807" height="719" alt="image" src="https://github.com/user-attachments/assets/eec6e0eb-16d2-4719-86cd-19c2a53c8d2d" /> |

※ I tested it in following repository.
https://github.com/amenonegames/LitMotionSequenceTest

# Related Issue
 #209 

