### PR TITLE
Fixes for fundamental flaws with TMP animators

### DIFF
--- a/src/LitMotion/Assets/LitMotion/Runtime/Extensions/TextMeshPro/LitMotionTextMeshProExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Extensions/TextMeshPro/LitMotionTextMeshProExtensions.cs
@@ -15,6 +15,8 @@ namespace LitMotion.Extensions
     /// </summary>
     public static class LitMotionTextMeshProExtensions
     {
+        private static void StaticOnComplete(TextMeshProMotionAnimator animator, int charIndex) => animator.CompleteForChar(charIndex);
+        
         /// <summary>
         /// Create a motion data and bind it to TMP_Text.fontSize
         /// </summary>
@@ -587,10 +589,12 @@ namespace LitMotion.Extensions
 
             var animator = TextMeshProMotionAnimator.Get(text);
             animator.EnsureCapacity(charIndex + 1);
-            var handle = builder.WithOnComplete(animator.updateAction).Bind(animator, Box.Create(charIndex), static (x, animator, charIndex) =>
+            
+            int index = charIndex;
+            var handle = builder.WithOnComplete(() => StaticOnComplete(animator, index)).Bind(animator, Box.Create(charIndex), static (x, animator, charIndex) =>
             {
                 animator.charInfoArray[charIndex.Value].color = x;
-                animator.SetDirty();
+                animator.SetCharDirty(charIndex.Value);
             });
 
             return handle;
@@ -613,10 +617,12 @@ namespace LitMotion.Extensions
 
             var animator = TextMeshProMotionAnimator.Get(text);
             animator.EnsureCapacity(charIndex + 1);
-            var handle = builder.WithOnComplete(animator.updateAction).Bind(animator, Box.Create(charIndex), static (x, animator, charIndex) =>
+
+            int index = charIndex;
+            var handle = builder.WithOnComplete(() => StaticOnComplete(animator, index)).Bind(animator, Box.Create(charIndex), static (x, animator, charIndex) =>
             {
                 animator.charInfoArray[charIndex.Value].color.r = x;
-                animator.SetDirty();
+                animator.SetCharDirty(charIndex.Value);
             });
 
             return handle;
@@ -639,10 +645,12 @@ namespace LitMotion.Extensions
 
             var animator = TextMeshProMotionAnimator.Get(text);
             animator.EnsureCapacity(charIndex + 1);
-            var handle = builder.WithOnComplete(animator.updateAction).Bind(animator, Box.Create(charIndex), static (x, animator, charIndex) =>
+    
+            int index = charIndex;
+            var handle = builder.WithOnComplete(() => StaticOnComplete(animator, index)).Bind(animator, Box.Create(charIndex), static (x, animator, charIndex) =>
             {
                 animator.charInfoArray[charIndex.Value].color.g = x;
-                animator.SetDirty();
+                animator.SetCharDirty(charIndex.Value);
             });
 
             return handle;
@@ -665,10 +673,12 @@ namespace LitMotion.Extensions
 
             var animator = TextMeshProMotionAnimator.Get(text);
             animator.EnsureCapacity(charIndex + 1);
-            var handle = builder.WithOnComplete(animator.updateAction).Bind(animator, Box.Create(charIndex), static (x, animator, charIndex) =>
+
+            int index = charIndex;
+            var handle = builder.WithOnComplete(() => StaticOnComplete(animator, index)).Bind(animator, Box.Create(charIndex), static (x, animator, charIndex) =>
             {
                 animator.charInfoArray[charIndex.Value].color.b = x;
-                animator.SetDirty();
+                animator.SetCharDirty(charIndex.Value);
             });
 
             return handle;
@@ -691,10 +701,12 @@ namespace LitMotion.Extensions
 
             var animator = TextMeshProMotionAnimator.Get(text);
             animator.EnsureCapacity(charIndex + 1);
-            var handle = builder.WithOnComplete(animator.updateAction).Bind(animator, Box.Create(charIndex), static (x, animator, charIndex) =>
+
+            int index = charIndex;
+            var handle = builder.WithOnComplete(() => StaticOnComplete(animator, index)).Bind(animator, Box.Create(charIndex), static (x, animator, charIndex) =>
             {
                 animator.charInfoArray[charIndex.Value].color.a = x;
-                animator.SetDirty();
+                animator.SetCharDirty(charIndex.Value);
             });
 
             return handle;
@@ -717,10 +729,12 @@ namespace LitMotion.Extensions
 
             var animator = TextMeshProMotionAnimator.Get(text);
             animator.EnsureCapacity(charIndex + 1);
-            var handle = builder.WithOnComplete(animator.updateAction).Bind(animator, Box.Create(charIndex), static (x, animator, charIndex) =>
+
+            int index = charIndex;
+            var handle = builder.WithOnComplete(() => StaticOnComplete(animator, index)).Bind(animator, Box.Create(charIndex), static (x, animator, charIndex) =>
             {
                 animator.charInfoArray[charIndex.Value].position = x;
-                animator.SetDirty();
+                animator.SetCharDirty(charIndex.Value);
             });
 
             return handle;
@@ -743,10 +757,12 @@ namespace LitMotion.Extensions
 
             var animator = TextMeshProMotionAnimator.Get(text);
             animator.EnsureCapacity(charIndex + 1);
-            var handle = builder.WithOnComplete(animator.updateAction).Bind(animator, Box.Create(charIndex), static (x, animator, charIndex) =>
+            
+            int index = charIndex;
+            var handle = builder.WithOnComplete(() => StaticOnComplete(animator, index)).Bind(animator, Box.Create(charIndex), static (x, animator, charIndex) =>
             {
                 animator.charInfoArray[charIndex.Value].position.x = x;
-                animator.SetDirty();
+                animator.SetCharDirty(charIndex.Value);
             });
 
             return handle;
@@ -769,10 +785,12 @@ namespace LitMotion.Extensions
 
             var animator = TextMeshProMotionAnimator.Get(text);
             animator.EnsureCapacity(charIndex + 1);
-            var handle = builder.WithOnComplete(animator.updateAction).Bind(animator, Box.Create(charIndex), static (x, animator, charIndex) =>
+            
+            int index = charIndex;
+            var handle = builder.WithOnComplete(() => StaticOnComplete(animator, index)).Bind(animator, Box.Create(charIndex), static (x, animator, charIndex) =>
             {
                 animator.charInfoArray[charIndex.Value].position.y = x;
-                animator.SetDirty();
+                animator.SetCharDirty(charIndex.Value);
             });
 
             return handle;
@@ -795,10 +813,12 @@ namespace LitMotion.Extensions
 
             var animator = TextMeshProMotionAnimator.Get(text);
             animator.EnsureCapacity(charIndex + 1);
-            var handle = builder.WithOnComplete(animator.updateAction).Bind(animator, Box.Create(charIndex), static (x, animator, charIndex) =>
+            
+            int index = charIndex;
+            var handle = builder.WithOnComplete(() => StaticOnComplete(animator, index)).Bind(animator, Box.Create(charIndex), static (x, animator, charIndex) =>
             {
                 animator.charInfoArray[charIndex.Value].position.z = x;
-                animator.SetDirty();
+                animator.SetCharDirty(charIndex.Value);
             });
 
             return handle;
@@ -821,10 +841,12 @@ namespace LitMotion.Extensions
 
             var animator = TextMeshProMotionAnimator.Get(text);
             animator.EnsureCapacity(charIndex + 1);
-            var handle = builder.WithOnComplete(animator.updateAction).Bind(animator, Box.Create(charIndex), static (x, animator, charIndex) =>
+
+            int index = charIndex;
+            var handle = builder.WithOnComplete(() => StaticOnComplete(animator, index)).Bind(animator, Box.Create(charIndex), static (x, animator, charIndex) =>
             {
                 animator.charInfoArray[charIndex.Value].rotation = x;
-                animator.SetDirty();
+                animator.SetCharDirty(charIndex.Value);
             });
 
             return handle;
@@ -847,10 +869,12 @@ namespace LitMotion.Extensions
 
             var animator = TextMeshProMotionAnimator.Get(text);
             animator.EnsureCapacity(charIndex + 1);
-            var handle = builder.WithOnComplete(animator.updateAction).Bind(animator, Box.Create(charIndex), static (x, animator, charIndex) =>
+
+            int index = charIndex;
+            var handle = builder.WithOnComplete(() => StaticOnComplete(animator, index)).Bind(animator, Box.Create(charIndex), static (x, animator, charIndex) =>
             {
                 animator.charInfoArray[charIndex.Value].rotation = Quaternion.Euler(x);
-                animator.SetDirty();
+                animator.SetCharDirty(charIndex.Value);
             });
 
             return handle;
@@ -873,12 +897,14 @@ namespace LitMotion.Extensions
 
             var animator = TextMeshProMotionAnimator.Get(text);
             animator.EnsureCapacity(charIndex + 1);
-            var handle = builder.WithOnComplete(animator.updateAction).Bind(animator, Box.Create(charIndex), static (x, animator, charIndex) =>
+
+            int index = charIndex;
+            var handle = builder.WithOnComplete(() => StaticOnComplete(animator, index)).Bind(animator, Box.Create(charIndex), static (x, animator, charIndex) =>
             {
                 var eulerAngles = animator.charInfoArray[charIndex.Value].rotation.eulerAngles;
                 eulerAngles.x = x;
                 animator.charInfoArray[charIndex.Value].rotation = Quaternion.Euler(eulerAngles);
-                animator.SetDirty();
+                animator.SetCharDirty(charIndex.Value);
             });
 
             return handle;
@@ -901,12 +927,14 @@ namespace LitMotion.Extensions
 
             var animator = TextMeshProMotionAnimator.Get(text);
             animator.EnsureCapacity(charIndex + 1);
-            var handle = builder.WithOnComplete(animator.updateAction).Bind(animator, Box.Create(charIndex), static (x, animator, charIndex) =>
+
+            int index = charIndex;
+            var handle = builder.WithOnComplete(() => StaticOnComplete(animator, index)).Bind(animator, Box.Create(charIndex), static (x, animator, charIndex) =>
             {
                 var eulerAngles = animator.charInfoArray[charIndex.Value].rotation.eulerAngles;
                 eulerAngles.y = x;
                 animator.charInfoArray[charIndex.Value].rotation = Quaternion.Euler(eulerAngles);
-                animator.SetDirty();
+                animator.SetCharDirty(charIndex.Value);
             });
 
             return handle;
@@ -929,12 +957,14 @@ namespace LitMotion.Extensions
 
             var animator = TextMeshProMotionAnimator.Get(text);
             animator.EnsureCapacity(charIndex + 1);
-            var handle = builder.WithOnComplete(animator.updateAction).Bind(animator, Box.Create(charIndex), static (x, animator, charIndex) =>
+
+            int index = charIndex;
+            var handle = builder.WithOnComplete(() => StaticOnComplete(animator, index)).Bind(animator, Box.Create(charIndex), static (x, animator, charIndex) =>
             {
                 var eulerAngles = animator.charInfoArray[charIndex.Value].rotation.eulerAngles;
                 eulerAngles.z = x;
                 animator.charInfoArray[charIndex.Value].rotation = Quaternion.Euler(eulerAngles);
-                animator.SetDirty();
+                animator.SetCharDirty(charIndex.Value);
             });
 
             return handle;
@@ -957,10 +987,12 @@ namespace LitMotion.Extensions
 
             var animator = TextMeshProMotionAnimator.Get(text);
             animator.EnsureCapacity(charIndex + 1);
-            var handle = builder.WithOnComplete(animator.updateAction).Bind(animator, Box.Create(charIndex), static (x, animator, charIndex) =>
+
+            int index = charIndex;
+            var handle = builder.WithOnComplete(() => StaticOnComplete(animator, index)).Bind(animator, Box.Create(charIndex), static (x, animator, charIndex) =>
             {
                 animator.charInfoArray[charIndex.Value].scale = x;
-                animator.SetDirty();
+                animator.SetCharDirty(charIndex.Value);
             });
 
             return handle;
@@ -983,10 +1015,12 @@ namespace LitMotion.Extensions
 
             var animator = TextMeshProMotionAnimator.Get(text);
             animator.EnsureCapacity(charIndex + 1);
-            var handle = builder.WithOnComplete(animator.updateAction).Bind(animator, Box.Create(charIndex), static (x, animator, charIndex) =>
+
+            int index = charIndex;
+            var handle = builder.WithOnComplete(() => StaticOnComplete(animator, index)).Bind(animator, Box.Create(charIndex), static (x, animator, charIndex) =>
             {
                 animator.charInfoArray[charIndex.Value].scale.x = x;
-                animator.SetDirty();
+                animator.SetCharDirty(charIndex.Value);
             });
 
             return handle;
@@ -1009,10 +1043,12 @@ namespace LitMotion.Extensions
 
             var animator = TextMeshProMotionAnimator.Get(text);
             animator.EnsureCapacity(charIndex + 1);
-            var handle = builder.WithOnComplete(animator.updateAction).Bind(animator, Box.Create(charIndex), static (x, animator, charIndex) =>
+
+            int index = charIndex;
+            var handle = builder.WithOnComplete(() => StaticOnComplete(animator, index)).Bind(animator, Box.Create(charIndex), static (x, animator, charIndex) =>
             {
                 animator.charInfoArray[charIndex.Value].scale.y = x;
-                animator.SetDirty();
+                animator.SetCharDirty(charIndex.Value);
             });
 
             return handle;
@@ -1035,10 +1071,12 @@ namespace LitMotion.Extensions
 
             var animator = TextMeshProMotionAnimator.Get(text);
             animator.EnsureCapacity(charIndex + 1);
-            var handle = builder.WithOnComplete(animator.updateAction).Bind(animator, Box.Create(charIndex), static (x, animator, charIndex) =>
+
+            int index = charIndex;
+            var handle = builder.WithOnComplete(() => StaticOnComplete(animator, index)).Bind(animator, Box.Create(charIndex), static (x, animator, charIndex) =>
             {
                 animator.charInfoArray[charIndex.Value].scale.z = x;
-                animator.SetDirty();
+                animator.SetCharDirty(charIndex.Value);
             });
 
             return handle;

--- a/src/LitMotion/Assets/LitMotion/Runtime/Extensions/TextMeshPro/TextMeshProMotionAnimator.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/Extensions/TextMeshPro/TextMeshProMotionAnimator.cs
@@ -47,7 +47,10 @@ namespace LitMotion.Extensions
         {
             if (textToAnimator.TryGetValue(text, out var animator))
             {
-                animator.Reset();
+                if (!animator.GetIsDirty())
+                {
+                    animator.Reset();
+                }
                 return animator;
             }
 
@@ -158,6 +161,7 @@ namespace LitMotion.Extensions
             public Vector3 scale;
             public Quaternion rotation;
             public Color color;
+            public bool isDirty;
         }
 
         public TextMeshProMotionAnimator()
@@ -169,16 +173,15 @@ namespace LitMotion.Extensions
                 charInfoArray[i].rotation = Quaternion.identity;
                 charInfoArray[i].scale = Vector3.one;
                 charInfoArray[i].position = Vector3.zero;
+                charInfoArray[i].isDirty = false;
             }
-
-            updateAction = UpdateCore;
         }
 
         TMP_Text target;
-        internal readonly Action updateAction;
         internal CharInfo[] charInfoArray;
-        bool isDirty;
-
+        bool dirtyFromComplete;
+        int lastDirtyChar = -1;
+        
         TextMeshProMotionAnimator nextNode;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -197,23 +200,32 @@ namespace LitMotion.Extensions
                         charInfoArray[i].rotation = Quaternion.identity;
                         charInfoArray[i].scale = Vector3.one;
                         charInfoArray[i].position = Vector3.zero;
+                        charInfoArray[i].isDirty = false;
                     }
                 }
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Update()
+        public void SetCharDirty(int charIndex)
         {
-            TryUpdate();
+            EnsureCapacity(charIndex + 1);
+            if (charIndex > lastDirtyChar)
+            {
+                lastDirtyChar = charIndex;
+            }
+            charInfoArray[charIndex].isDirty = true;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void SetDirty()
+        bool GetIsDirty()
         {
-            isDirty = true;
+            if (dirtyFromComplete)
+            {
+                return true;
+            }
+            return lastDirtyChar >= 0;
         }
-
+        
         public void Reset()
         {
             for (int i = 0; i < charInfoArray.Length; i++)
@@ -222,29 +234,27 @@ namespace LitMotion.Extensions
                 charInfoArray[i].rotation = Quaternion.identity;
                 charInfoArray[i].scale = Vector3.one;
                 charInfoArray[i].position = Vector3.zero;
+                charInfoArray[i].isDirty = false;
             }
-
-            isDirty = false;
+            dirtyFromComplete = false;
         }
-
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         bool TryUpdate()
         {
             if (target == null) return false;
-
-            if (isDirty)
+            
+            if (GetIsDirty())
             {
                 UpdateCore();
+                return true;
             }
-
-            return true;
+            return false;
         }
 
         void UpdateCore()
         {
             target.ForceMeshUpdate();
-
             var textInfo = target.textInfo;
             EnsureCapacity(textInfo.characterCount);
 
@@ -288,6 +298,30 @@ namespace LitMotion.Extensions
                 textInfo.meshInfo[i].mesh.vertices = textInfo.meshInfo[i].vertices;
                 target.UpdateGeometry(textInfo.meshInfo[i].mesh, i);
             }
+
+            if (dirtyFromComplete)
+            {
+                dirtyFromComplete = false;
+            }
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void CompleteForChar(int charIndex)
+        {
+            EnsureCapacity(charIndex + 1);
+            charInfoArray[charIndex].isDirty = false;
+            if (charIndex >= lastDirtyChar)
+            {
+                lastDirtyChar = -1;
+                for (int i = charIndex; i >= 0; i--)
+                {
+                    if (charInfoArray[i].isDirty)
+                    {
+                        lastDirtyChar = i;
+                    }
+                }
+            }
+            dirtyFromComplete = true;
         }
     }
 }


### PR DESCRIPTION
The previous implementation would never reset the animator or return it to the pool as isDirty was not set back to false upon completion. The requirements for returning the the pool where based on TryUpdate returning false. This method only returned false if the target is null. The target was only set to null internall during it's return to the pool so animators are only released if the target object is destroyed entirely.

This resolves this by introducing a per-character dirty flag to ensure that dirty animators can be tracked more effectively. 

This has required introducing minor allocations through the closures capturing the character index and animator within the extension methods.