### PR TITLE
Add [Serializable] to suppress serialization warning on Unity 6000.*

### DIFF
--- a/src/LitMotion/Assets/LitMotion.Animation/Runtime/Components/TransformComponents.cs
+++ b/src/LitMotion/Assets/LitMotion.Animation/Runtime/Components/TransformComponents.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 
 namespace LitMotion.Animation.Components
 {
+    [Serializable]
     public abstract class TransformPositionAnimationBase<TOptions, TAdapter> : PropertyAnimationComponent<Transform, Vector3, TOptions, TAdapter>
         where TOptions : unmanaged, IMotionOptions
         where TAdapter : unmanaged, IMotionAdapter<Vector3, TOptions>
@@ -40,6 +41,7 @@ namespace LitMotion.Animation.Components
     [LitMotionAnimationComponentMenu("Transform/Position (Shake)")]
     public sealed class TransformPositionShakeAnimation : TransformPositionAnimationBase<ShakeOptions, Vector3ShakeMotionAdapter> { }
 
+    [Serializable]
     public abstract class TransformRotationAnimationBase<TOptions, TAdapter> : PropertyAnimationComponent<Transform, Vector3, TOptions, TAdapter>
         where TOptions : unmanaged, IMotionOptions
         where TAdapter : unmanaged, IMotionAdapter<Vector3, TOptions>
@@ -75,6 +77,7 @@ namespace LitMotion.Animation.Components
     [LitMotionAnimationComponentMenu("Transform/Rotation (Shake)")]
     public sealed class TransformRotationShakeAnimation : TransformRotationAnimationBase<ShakeOptions, Vector3ShakeMotionAdapter> { }
 
+    [Serializable]
     public abstract class TransformScaleAnimationBase<TOptions, TAdapter> : PropertyAnimationComponent<Transform, Vector3, TOptions, TAdapter>
         where TOptions : unmanaged, IMotionOptions
         where TAdapter : unmanaged, IMotionAdapter<Vector3, TOptions>

--- a/src/LitMotion/Assets/LitMotion.Animation/Runtime/PropertyAnimationComponent.cs
+++ b/src/LitMotion/Assets/LitMotion.Animation/Runtime/PropertyAnimationComponent.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 
 namespace LitMotion.Animation
 {
+    [Serializable]
     public abstract class PropertyAnimationComponent<TObject, TValue, TOptions, TAdapter> : LitMotionAnimationComponent
         where TObject : UnityEngine.Object
         where TValue : unmanaged


### PR DESCRIPTION
Hi, I spot latest editor versions are checking for explicit [Serializable] even on the abstract class. Thus they will warn this upon every domain reload:

```
2026-03-11T11:54:01.195Z|0x6c7c|The type LitMotion.Animation LitMotion.Animation.Components.TransformPositionAnimation is being serialized by [SerializeReference], but its parent type LitMotion.Animation LitMotion.Animation.Components.TransformPositionAnimationBase`2 is missing the [Serializable] attribute. To suppress this warning add [Serializable] to LitMotion.Animation LitMotion.Animation.Components.TransformPositionAnimationBase`2 or use [MakeSerializable].
...
```

So it'd be nice to have a explicit attribute.