### PR TITLE
6.5 Fixes

### DIFF
--- a/src/LitMotion/Assets/LitMotion/Editor/MotionDebuggerTreeView.cs
+++ b/src/LitMotion/Assets/LitMotion/Editor/MotionDebuggerTreeView.cs
@@ -7,6 +7,12 @@ using UnityEngine;
 using UnityEditor;
 using UnityEditor.IMGUI.Controls;
 
+#if UNITY_6000_2_OR_NEWER
+using TreeView = UnityEditor.IMGUI.Controls.TreeView<int>;
+using TreeViewItem = UnityEditor.IMGUI.Controls.TreeViewItem<int>;
+using TreeViewState = UnityEditor.IMGUI.Controls.TreeViewState<int>;
+#endif
+
 namespace LitMotion.Editor
 {
     internal sealed class MotionDebuggerViewItem : TreeViewItem


### PR DESCRIPTION
This fixes all the errors introduced with Unity 6.5 whilst keeping backwards compatibility.
This should just work, but I recommend doing testing to make sure all is good.