### PR TITLE
Add R3.CompositeDisposable support to AddTo extension

### DIFF
--- a/src/LitMotion/Assets/LitMotion/Runtime/External/R3/LitMotionR3Extensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/External/R3/LitMotionR3Extensions.cs
@@ -46,6 +46,54 @@ namespace LitMotion
                 target.Value = x;
             });
         }
+
+        /// <summary>
+        /// Add this motion handle to R3 CompositeDisposable.
+        /// </summary>
+        /// <param name="handle">This motion handle</param>
+        /// <param name="disposable">Target CompositeDisposable</param>
+        /// <param name="disposeBehavior">Behavior when the disposable is disposed</param>
+        public static MotionHandle AddTo(this MotionHandle handle, CompositeDisposable disposable, DisposeBehavior disposeBehavior = DisposeBehavior.Cancel)
+        {
+            disposable.Add(handle.ToDisposable(disposeBehavior));
+            return handle;
+        }
+
+        /// <summary>
+        /// Add this motion handle to R3 SerialDisposable.
+        /// </summary>
+        /// <param name="handle">This motion handle</param>
+        /// <param name="disposable">Target SerialDisposable</param>
+        /// <param name="disposeBehavior">Behavior when the disposable is disposed</param>
+        public static MotionHandle AddTo(this MotionHandle handle, SerialDisposable disposable, DisposeBehavior disposeBehavior = DisposeBehavior.Cancel)
+        {
+            disposable.Disposable = handle.ToDisposable(disposeBehavior);
+            return handle;
+        }
+
+        /// <summary>
+        /// Add this motion handle to R3 DisposableBag.
+        /// </summary>
+        /// <param name="handle">This motion handle</param>
+        /// <param name="disposable">Target DisposableBag</param>
+        /// <param name="disposeBehavior">Behavior when the disposable is disposed</param>
+        public static MotionHandle AddTo(this MotionHandle handle, ref DisposableBag disposable, DisposeBehavior disposeBehavior = DisposeBehavior.Cancel)
+        {
+            disposable.Add(handle.ToDisposable(disposeBehavior));
+            return handle;
+        }
+
+        /// <summary>
+        /// Add this motion handle to R3 DisposableBuilder.
+        /// </summary>
+        /// <param name="handle">This motion handle</param>
+        /// <param name="disposable">Target DisposableBuilder</param>
+        /// <param name="disposeBehavior">Behavior when the disposable is disposed</param>
+        public static MotionHandle AddTo(this MotionHandle handle, ref DisposableBuilder disposable, DisposeBehavior disposeBehavior = DisposeBehavior.Cancel)
+        {
+            disposable.Add(handle.ToDisposable(disposeBehavior));
+            return handle;
+        }
     }
 }
 #endif

--- a/src/LitMotion/Assets/LitMotion/Runtime/MotionHandleExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/MotionHandleExtensions.cs
@@ -176,6 +176,17 @@ namespace LitMotion
             return handle;
         }
 
+        /// <summary>
+        /// Add this motion handle to R3 CompositeDisposable.
+        /// </summary>
+        /// <param name="handle">This motion handle</param>
+        /// <param name="disposable">Target CompositeDisposable</param>
+        public static MotionHandle AddTo(this MotionHandle handle, global::R3.CompositeDisposable disposable)
+        {
+            disposable.Add(handle.ToDisposable());
+            return handle;
+        }
+
 #if UNITY_2022_2_OR_NEWER
         /// <summary>
         /// Link the motion lifecycle to the target object.

--- a/src/LitMotion/Assets/LitMotion/Runtime/MotionHandleExtensions.cs
+++ b/src/LitMotion/Assets/LitMotion/Runtime/MotionHandleExtensions.cs
@@ -176,17 +176,6 @@ namespace LitMotion
             return handle;
         }
 
-        /// <summary>
-        /// Add this motion handle to R3 CompositeDisposable.
-        /// </summary>
-        /// <param name="handle">This motion handle</param>
-        /// <param name="disposable">Target CompositeDisposable</param>
-        public static MotionHandle AddTo(this MotionHandle handle, global::R3.CompositeDisposable disposable)
-        {
-            disposable.Add(handle.ToDisposable());
-            return handle;
-        }
-
 #if UNITY_2022_2_OR_NEWER
         /// <summary>
         /// Link the motion lifecycle to the target object.


### PR DESCRIPTION
Adds AddTo(R3.CompositeDisposable) overload for MotionHandle.

This allows motion handles to be added to R3's CompositeDisposable,
which automatically cancels the motion when disposed.