### PR TITLE
[LitMotionAnimation] Fix: Context for LogException

### DIFF
--- a/src/LitMotion/Assets/LitMotion.Animation/Runtime/LitMotionAnimation.cs
+++ b/src/LitMotion/Assets/LitMotion.Animation/Runtime/LitMotionAnimation.cs
@@ -72,7 +72,7 @@ namespace LitMotion.Animation
                 }
                 catch (Exception ex)
                 {
-                    Debug.LogException(ex);
+                    Debug.LogException(ex, context: this);
                 }
             }
         }
@@ -129,7 +129,7 @@ namespace LitMotion.Animation
                         }
                         catch (Exception ex)
                         {
-                            Debug.LogException(ex);
+                            Debug.LogException(ex, context: this);
                         }
                     }
                     break;


### PR DESCRIPTION
Without this fix, it is unclear which LitMotionAnimation component generated the exception.

https://github.com/user-attachments/assets/b46b39db-2dbb-44a1-973b-aa7673679d68

